### PR TITLE
Add Sagitta v3 design documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,113 @@
 # vyos-onecontext
 
-OpenNebula contextualization for VyOS router images.
+OpenNebula contextualization for VyOS Sagitta (1.4.x) router images.
+
+## Overview
+
+This repository provides scripts that configure VyOS routers at boot time based on
+OpenNebula context variables. Routers are stateless - all configuration derives from
+context on every boot.
+
+## Documentation
+
+- [Design Document](docs/design.md) - Architecture and design decisions
+- [Context Variable Reference](docs/context-reference.md) - All supported variables with examples
 
 ## Branches
 
 - **sagitta** - VyOS Sagitta (1.4.x LTS) - active development
 - **legacy/equuleus** - VyOS Equuleus (1.3.x) - maintenance only, EOL upstream
 
-## Status
+## Quick Start
 
-Sagitta contextualization is under development. See the [vrouter-v3 project docs](https://github.com/SouthwestCCDC/deployment/tree/main/docs/docs/projects/backlog/vyos-router-v3) for requirements and progress.
+Context variables are set in your OpenNebula VM template or Terraform configuration:
+
+```hcl
+context = {
+  NETWORK        = "YES"
+  HOSTNAME       = "router-01"
+  SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+
+  # Management interface in VRF
+  ETH0_VROUTER_MANAGEMENT = "YES"
+
+  # Static routes (JSON format)
+  ROUTES_JSON = jsonencode({
+    static = [
+      { interface = "eth1", destination = "0.0.0.0/0", gateway = "10.0.1.254" }
+    ]
+  })
+
+  # OSPF (JSON format)
+  OSPF_JSON = jsonencode({
+    enabled = true
+    areas = [{ id = "0.0.0.0", networks = ["10.0.0.0/8"] }]
+    redistribute = ["connected", "static"]
+  })
+}
+```
+
+See the [Context Variable Reference](docs/context-reference.md) for all options.
+
+## Features
+
+**Designed (implementation pending):**
+- Interface configuration (standard OpenNebula variables)
+- NIC aliases / secondary IPs (OpenNebula NIC alias support)
+- Management VRF (OpenNebula vrouter convention)
+- Static routing
+- OSPF with authentication and passive interfaces
+- DHCP server with pools and reservations
+- Source NAT (masquerading)
+- Destination NAT (port forwarding)
+- Bidirectional 1:1 NAT (using NIC aliases for external IPs)
+- Zone-based firewall (groups, zones, policies)
+- Custom VyOS commands (escape hatch)
+
+**Out of scope:**
+- VLAN-tagged interfaces (OpenNebula provides virtual NICs)
+- VPN (handled by dedicated infrastructure)
+- Captive portal, schedule-based rules
+
+## Development
+
+This project uses [uv](https://docs.astral.sh/uv/) for dependency management:
+
+```bash
+# Install dependencies
+uv sync
+
+# Run tests
+uv run pytest
+
+# Lint
+uv run ruff check .
+
+# Format
+uv run ruff format .
+
+# Type check
+uv run mypy src/
+```
+
+Or use the justfile:
+
+```bash
+just test      # Run tests
+just lint      # Run linter
+just fmt       # Format code
+just check     # Run all checks
+```
 
 ## Related
 
+**Project documentation (in deployment/docs/docs/):**
+
+- [VyOS Router v3 Project](../../../docs/docs/projects/active/vyos-router-v3/index.md) - Project overview and status
+- [Implementation Plan](../../../docs/docs/projects/active/vyos-router-v3/implementation-plan.md) - Phased implementation approach
+- [Requirements](../../../docs/docs/projects/active/vyos-router-v3/requirements.md) - Detailed requirements analysis
+
+**External:**
+
 - [deployment](https://github.com/SouthwestCCDC/deployment) - Packer builds and infrastructure
+- [VyOS Sagitta Documentation](https://docs.vyos.io/en/sagitta/)

--- a/docs/context-reference.md
+++ b/docs/context-reference.md
@@ -169,12 +169,7 @@ OSPF dynamic routing configuration.
   "areas": [
     {
       "id": "0.0.0.0",
-      "networks": ["10.0.0.0/8", "192.168.0.0/16"],
-      "authentication": {
-        "type": "md5",
-        "key_id": 1,
-        "key": "secretkey"
-      }
+      "networks": ["10.0.0.0/8", "192.168.0.0/16"]
     }
   ],
   "redistribute": ["connected", "static", "kernel"],
@@ -196,13 +191,13 @@ OSPF dynamic routing configuration.
 | `areas` | Array | Yes | OSPF area definitions |
 | `areas[].id` | String | Yes | Area ID (dotted-decimal, e.g., `0.0.0.0`) |
 | `areas[].networks` | Array | Yes | Networks to advertise in this area |
-| `areas[].authentication` | Object | No | Area authentication settings |
-| `areas[].authentication.type` | String | No | `md5` or `plaintext` |
-| `areas[].authentication.key_id` | Integer | No | Key ID (for MD5) |
-| `areas[].authentication.key` | String | No | Authentication key |
 | `redistribute` | Array | No | Protocols to redistribute |
 | `passive_interfaces` | Array | No | Interfaces that don't send OSPF hellos |
 | `default_information` | Object | No | Default route origination settings |
+
+> **Note:** OSPF authentication is not included in v1. The OSPF networks run on isolated
+> point-to-point links with adequate protection at the infrastructure level. Authentication
+> support may be added in a future version if needed.
 
 **Terraform Example:**
 
@@ -218,11 +213,6 @@ OSPF_JSON = jsonencode({
     {
       id = "10.64.0.0"
       networks = ["10.0.0.0/8"]
-      authentication = {
-        type = "md5"
-        key_id = 1
-        key = "ospf-secret"
-      }
     }
   ]
   redistribute = ["connected", "static"]
@@ -232,13 +222,11 @@ OSPF_JSON = jsonencode({
 
 **Generated VyOS Commands:**
 
-```
+```text
 set protocols ospf parameters router-id '10.64.0.1'
 set protocols ospf area 0.0.0.0 network '10.63.253.0/24'
 set protocols ospf area 0.0.0.0 network '10.4.0.0/24'
 set protocols ospf area 10.64.0.0 network '10.0.0.0/8'
-set protocols ospf area 10.64.0.0 authentication 'md5'
-set protocols ospf interface eth1 authentication md5 key-id 1 md5-key 'ospf-secret'
 set protocols ospf redistribute connected
 set protocols ospf redistribute static
 set protocols ospf passive-interface 'eth0'
@@ -766,7 +754,7 @@ Raw VyOS commands executed within the configuration transaction.
 
 | Variable | Type | Description |
 |----------|------|-------------|
-| `START_CONFIG` | String | VyOS commands (one per line, without `set` prefix optional) |
+| `START_CONFIG` | String | VyOS commands (one per line; `set` prefix is optional) |
 
 **Terraform Example:**
 
@@ -883,8 +871,8 @@ resource "opennebula_virtual_machine" "router" {
 
 **Project documentation (mkdocs site):**
 
-- [VyOS Router v3 Project](../../../../docs/docs/projects/backlog/vyos-router-v3/index.md) - Project overview and status
-- [Implementation Plan](../../../../docs/docs/projects/backlog/vyos-router-v3/implementation-plan.md) - Phased implementation approach
+- [VyOS Router v3 Project](../../../../docs/docs/projects/active/vyos-router-v3/index.md) - Project overview and status
+- [Implementation Plan](../../../../docs/docs/projects/active/vyos-router-v3/implementation-plan.md) - Phased implementation approach
 
 **Technical reference:**
 

--- a/docs/context-reference.md
+++ b/docs/context-reference.md
@@ -1,0 +1,895 @@
+# Context Variable Reference
+
+This document defines all context variables supported by VyOS Sagitta contextualization.
+
+## Standard OpenNebula Variables
+
+These variables follow OpenNebula conventions and provide basic network configuration.
+
+### Network Interface Variables
+
+For each interface (eth0, eth1, ...), the following variables are supported:
+
+| Variable | Type | Required | Description |
+|----------|------|----------|-------------|
+| `ETHx_IP` | IP address | No | IPv4 address for interface |
+| `ETHx_MASK` | Netmask | No | Dotted-decimal netmask (e.g., `255.255.255.0`) |
+| `ETHx_GATEWAY` | IP address | No | Default gateway via this interface |
+| `ETHx_DNS` | IP address | No | DNS server |
+| `ETHx_MTU` | Integer | No | Interface MTU |
+| `ETHx_VROUTER_MANAGEMENT` | `YES`/`NO` | No | Place interface in management VRF |
+
+**Example:**
+
+```bash
+ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+ETH0_GATEWAY="10.0.1.254"
+ETH0_DNS="8.8.8.8"
+ETH0_MTU="1500"
+ETH0_VROUTER_MANAGEMENT="YES"
+```
+
+**Notes:**
+
+- If `ETHx_GATEWAY` is set and the interface is not management, a default route is added
+- Multiple interfaces can have `VROUTER_MANAGEMENT="YES"` (all go in management VRF)
+- Netmask is converted to CIDR prefix automatically
+
+### NIC Alias Variables (Secondary IPs)
+
+OpenNebula NIC aliases provide additional IP addresses on the same interface. These are
+used for 1:1 NAT scenarios where additional public IPs are needed.
+
+For each alias on an interface, the following variables are provided:
+
+| Variable | Type | Required | Description |
+|----------|------|----------|-------------|
+| `ETHx_ALIASy_IP` | IP address | No | IPv4 address for alias |
+| `ETHx_ALIASy_MASK` | Netmask | No | Dotted-decimal netmask (may be empty due to ONE bug) |
+| `ETHx_ALIASy_MAC` | MAC address | No | MAC address (same as parent interface) |
+
+**Example:**
+
+```bash
+# Primary interface
+ETH0_IP="129.244.246.64"
+ETH0_MASK="255.255.255.0"
+
+# First alias (for scoring engine 1:1 NAT)
+ETH0_ALIAS0_IP="129.244.246.66"
+ETH0_ALIAS0_MASK="255.255.255.0"
+
+# Second alias (for another service)
+ETH0_ALIAS1_IP="129.244.246.67"
+ETH0_ALIAS1_MASK="255.255.255.0"
+```
+
+**Notes:**
+
+- Aliases are configured in Terraform using `nic_alias` blocks
+- OpenNebula manages IP allocation from the virtual network
+- The contextualization script adds these as secondary addresses on the interface
+- If `ETHx_ALIASy_MASK` is empty (known ONE bug), the parent interface mask is used
+- Alias IPs can be referenced in `NAT_JSON` binat rules for 1:1 NAT
+
+### Identity Variables
+
+| Variable | Type | Required | Description |
+|----------|------|----------|-------------|
+| `HOSTNAME` | String | No | System hostname |
+| `SSH_PUBLIC_KEY` | String | No | SSH public key for vyos user |
+
+**Example:**
+
+```bash
+HOSTNAME="router-01"
+SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAA... user@host"
+```
+
+---
+
+## JSON Extension Variables
+
+These variables use JSON encoding for complex configuration. In Terraform, use `jsonencode()`:
+
+```hcl
+context = {
+  ROUTES_JSON = jsonencode({
+    static = [
+      { interface = "eth1", destination = "0.0.0.0/0", gateway = "10.63.255.1" }
+    ]
+  })
+}
+```
+
+### ROUTES_JSON
+
+Static routing configuration.
+
+**Schema:**
+
+```json
+{
+  "static": [
+    {
+      "interface": "eth1",
+      "destination": "0.0.0.0/0",
+      "gateway": "10.63.255.1",
+      "distance": 1,
+      "vrf": "management"
+    }
+  ]
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `static` | Array | Yes | List of static routes |
+| `static[].interface` | String | Yes | Egress interface |
+| `static[].destination` | CIDR | Yes | Destination network |
+| `static[].gateway` | IP | No | Next-hop gateway (if not specified, uses interface route) |
+| `static[].distance` | Integer | No | Administrative distance (default: 1) |
+| `static[].vrf` | String | No | VRF name (default: main routing table) |
+
+**Terraform Example:**
+
+```hcl
+ROUTES_JSON = jsonencode({
+  static = [
+    { interface = "eth1", destination = "0.0.0.0/0", gateway = "10.63.255.1" },
+    { interface = "eth2", destination = "10.96.0.0/13", gateway = "10.69.100.1" },
+    { interface = "eth0", destination = "192.168.0.0/16", gateway = "10.0.1.254", vrf = "management" }
+  ]
+})
+```
+
+**Generated VyOS Commands:**
+
+```
+set protocols static route 0.0.0.0/0 next-hop 10.63.255.1
+set protocols static route 10.96.0.0/13 next-hop 10.69.100.1
+set vrf name management protocols static route 192.168.0.0/16 next-hop 10.0.1.254
+```
+
+---
+
+### OSPF_JSON
+
+OSPF dynamic routing configuration.
+
+**Schema:**
+
+```json
+{
+  "enabled": true,
+  "router_id": "10.0.0.1",
+  "areas": [
+    {
+      "id": "0.0.0.0",
+      "networks": ["10.0.0.0/8", "192.168.0.0/16"],
+      "authentication": {
+        "type": "md5",
+        "key_id": 1,
+        "key": "secretkey"
+      }
+    }
+  ],
+  "redistribute": ["connected", "static", "kernel"],
+  "passive_interfaces": ["eth0"],
+  "default_information": {
+    "originate": true,
+    "always": true,
+    "metric": 100
+  }
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `enabled` | Boolean | Yes | Enable OSPF |
+| `router_id` | IP | No | OSPF router ID (auto-derived if not set) |
+| `areas` | Array | Yes | OSPF area definitions |
+| `areas[].id` | String | Yes | Area ID (dotted-decimal, e.g., `0.0.0.0`) |
+| `areas[].networks` | Array | Yes | Networks to advertise in this area |
+| `areas[].authentication` | Object | No | Area authentication settings |
+| `areas[].authentication.type` | String | No | `md5` or `plaintext` |
+| `areas[].authentication.key_id` | Integer | No | Key ID (for MD5) |
+| `areas[].authentication.key` | String | No | Authentication key |
+| `redistribute` | Array | No | Protocols to redistribute |
+| `passive_interfaces` | Array | No | Interfaces that don't send OSPF hellos |
+| `default_information` | Object | No | Default route origination settings |
+
+**Terraform Example:**
+
+```hcl
+OSPF_JSON = jsonencode({
+  enabled = true
+  router_id = "10.64.0.1"
+  areas = [
+    {
+      id = "0.0.0.0"
+      networks = ["10.63.253.0/24", "10.4.0.0/24"]
+    },
+    {
+      id = "10.64.0.0"
+      networks = ["10.0.0.0/8"]
+      authentication = {
+        type = "md5"
+        key_id = 1
+        key = "ospf-secret"
+      }
+    }
+  ]
+  redistribute = ["connected", "static"]
+  passive_interfaces = ["eth0"]
+})
+```
+
+**Generated VyOS Commands:**
+
+```
+set protocols ospf parameters router-id '10.64.0.1'
+set protocols ospf area 0.0.0.0 network '10.63.253.0/24'
+set protocols ospf area 0.0.0.0 network '10.4.0.0/24'
+set protocols ospf area 10.64.0.0 network '10.0.0.0/8'
+set protocols ospf area 10.64.0.0 authentication 'md5'
+set protocols ospf interface eth1 authentication md5 key-id 1 md5-key 'ospf-secret'
+set protocols ospf redistribute connected
+set protocols ospf redistribute static
+set protocols ospf passive-interface 'eth0'
+```
+
+---
+
+### DHCP_JSON
+
+DHCP server configuration.
+
+**Schema:**
+
+```json
+{
+  "pools": [
+    {
+      "interface": "eth1",
+      "subnet": "10.1.1.0/24",
+      "range_start": "10.1.1.100",
+      "range_end": "10.1.1.200",
+      "gateway": "10.1.1.1",
+      "dns": ["10.1.1.1", "8.8.8.8"],
+      "lease_time": 86400,
+      "domain": "example.local"
+    }
+  ],
+  "reservations": [
+    {
+      "interface": "eth1",
+      "mac": "00:11:22:33:44:55",
+      "ip": "10.1.1.50",
+      "hostname": "server01"
+    }
+  ]
+}
+```
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `pools` | Array | No | DHCP pools |
+| `pools[].interface` | String | Yes | Interface for this pool |
+| `pools[].subnet` | CIDR | No | Subnet (auto-derived from interface if not set) |
+| `pools[].range_start` | IP | Yes | First IP in range |
+| `pools[].range_end` | IP | Yes | Last IP in range |
+| `pools[].gateway` | IP | Yes | Default gateway for clients |
+| `pools[].dns` | Array | Yes | DNS servers for clients |
+| `pools[].lease_time` | Integer | No | Lease time in seconds |
+| `pools[].domain` | String | No | Domain name for clients |
+| `reservations` | Array | No | Static DHCP reservations |
+| `reservations[].interface` | String | Yes | Interface for reservation |
+| `reservations[].mac` | String | Yes | Client MAC address |
+| `reservations[].ip` | IP | Yes | Reserved IP address |
+| `reservations[].hostname` | String | No | Hostname for client |
+
+**Terraform Example:**
+
+```hcl
+DHCP_JSON = jsonencode({
+  pools = [
+    {
+      interface = "eth1"
+      range_start = "10.61.0.64"
+      range_end = "10.61.0.240"
+      gateway = "10.61.0.1"
+      dns = ["10.63.4.101"]
+    }
+  ]
+  reservations = [
+    {
+      interface = "eth1"
+      mac = "00:11:22:33:44:55"
+      ip = "10.61.0.50"
+      hostname = "printer01"
+    }
+  ]
+})
+```
+
+---
+
+### NAT_JSON
+
+NAT configuration for source NAT (masquerading), destination NAT (port forwarding), and
+bidirectional 1:1 NAT.
+
+**Schema:**
+
+```json
+{
+  "source": [
+    {
+      "outbound_interface": "eth1",
+      "source_address": "10.0.0.0/8",
+      "translation": "masquerade"
+    },
+    {
+      "outbound_interface": "eth1",
+      "source_address": "192.168.0.0/16",
+      "translation_address": "203.0.113.10"
+    }
+  ],
+  "destination": [
+    {
+      "inbound_interface": "eth1",
+      "protocol": "tcp",
+      "destination_port": 443,
+      "translation_address": "10.62.0.20",
+      "translation_port": 443,
+      "description": "HTTPS to internal server"
+    }
+  ],
+  "binat": [
+    {
+      "external_address": "129.244.246.66",
+      "internal_address": "10.63.0.101",
+      "interface": "eth0",
+      "description": "Scoring engine"
+    }
+  ]
+}
+```
+
+**Source NAT Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `outbound_interface` | String | Yes | Egress interface |
+| `source_address` | CIDR | No | Source network to NAT |
+| `translation` | String | No | `masquerade` for dynamic SNAT |
+| `translation_address` | IP/Range | No | Static SNAT address |
+| `description` | String | No | Rule description |
+
+**Destination NAT Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `inbound_interface` | String | Yes | Ingress interface |
+| `protocol` | String | No | `tcp`, `udp`, or `tcp_udp` |
+| `destination_address` | IP | No | Original destination (for 1:1 NAT) |
+| `destination_port` | Integer | No | Original destination port |
+| `translation_address` | IP | Yes | New destination address |
+| `translation_port` | Integer | No | New destination port |
+| `description` | String | No | Rule description |
+
+**Bidirectional NAT (1:1) Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `external_address` | IP | Yes | External/public IP (must be alias on interface) |
+| `internal_address` | IP | Yes | Internal IP to map to |
+| `interface` | String | Yes | Interface where external IP is assigned |
+| `description` | String | No | Rule description |
+
+**Notes on Bidirectional NAT:**
+
+- The `external_address` must be configured as a NIC alias in Terraform
+- OpenNebula manages the IP lease; context provides it as `ETHx_ALIASy_IP`
+- The contextualization script verifies the alias IP exists before creating NAT rules
+- Creates both source and destination NAT rules for full bidirectional translation
+
+**Terraform Example:**
+
+```hcl
+NAT_JSON = jsonencode({
+  source = [
+    {
+      outbound_interface = "eth0"
+      source_address = "10.0.0.0/8"
+      translation = "masquerade"
+    }
+  ]
+  destination = [
+    {
+      inbound_interface = "eth0"
+      protocol = "tcp"
+      destination_port = 443
+      translation_address = "10.62.0.20"
+      description = "HTTPS to web server"
+    },
+    {
+      inbound_interface = "eth0"
+      protocol = "tcp"
+      destination_port = 2222
+      translation_address = "10.62.0.30"
+      translation_port = 22
+      description = "SSH to jump host"
+    }
+  ]
+  binat = [
+    {
+      external_address = "129.244.246.66"
+      internal_address = "10.63.0.101"
+      interface = "eth0"
+      description = "Scoring engine"
+    }
+  ]
+})
+```
+
+**Generated VyOS Commands:**
+
+```
+# Source NAT (masquerade)
+set nat source rule 100 outbound-interface name 'eth0'
+set nat source rule 100 source address '10.0.0.0/8'
+set nat source rule 100 translation address 'masquerade'
+
+# Destination NAT (port forwards)
+set nat destination rule 100 inbound-interface name 'eth0'
+set nat destination rule 100 protocol 'tcp'
+set nat destination rule 100 destination port '443'
+set nat destination rule 100 translation address '10.62.0.20'
+set nat destination rule 100 description 'HTTPS to web server'
+
+set nat destination rule 101 inbound-interface name 'eth0'
+set nat destination rule 101 protocol 'tcp'
+set nat destination rule 101 destination port '2222'
+set nat destination rule 101 translation address '10.62.0.30'
+set nat destination rule 101 translation port '22'
+set nat destination rule 101 description 'SSH to jump host'
+
+# Bidirectional NAT (1:1)
+# Inbound: external -> internal
+set nat destination rule 200 inbound-interface name 'eth0'
+set nat destination rule 200 destination address '129.244.246.66'
+set nat destination rule 200 translation address '10.63.0.101'
+set nat destination rule 200 description 'Scoring engine'
+
+# Outbound: internal -> external
+set nat source rule 200 outbound-interface name 'eth0'
+set nat source rule 200 source address '10.63.0.101'
+set nat source rule 200 translation address '129.244.246.66'
+set nat source rule 200 description 'Scoring engine'
+```
+
+---
+
+### FIREWALL_JSON
+
+Zone-based firewall configuration with groups, zones, and policies.
+
+**Schema:**
+
+```json
+{
+  "groups": {
+    "network": {
+      "GAME": ["10.64.0.0/10", "10.128.0.0/9"],
+      "SCORING": ["10.62.0.0/16"],
+      "OK_FROM_GAME": ["10.63.4.0/24", "10.61.0.0/23"]
+    },
+    "address": {
+      "SCORING_ENGINE": ["10.63.0.101"],
+      "DNS_SERVERS": ["10.63.4.101", "8.8.8.8"]
+    },
+    "port": {
+      "WEB": [80, 443],
+      "SSH": [22],
+      "DNS": [53]
+    }
+  },
+  "zones": {
+    "WAN": {
+      "interfaces": ["eth0"],
+      "default_action": "drop"
+    },
+    "GAME": {
+      "interfaces": ["eth1", "eth2"],
+      "default_action": "drop"
+    },
+    "SCORING": {
+      "interfaces": ["eth3"],
+      "default_action": "drop"
+    }
+  },
+  "policies": [
+    {
+      "from": "GAME",
+      "to": "SCORING",
+      "rules": [
+        {
+          "action": "accept",
+          "protocol": "tcp",
+          "destination_port_group": "WEB",
+          "description": "Allow web traffic"
+        }
+      ]
+    },
+    {
+      "from": "WAN",
+      "to": "SCORING",
+      "rules": [
+        {
+          "action": "accept",
+          "destination_address_group": "SCORING_ENGINE",
+          "description": "Allow NAT'd traffic to scoring"
+        }
+      ]
+    },
+    {
+      "from": "SCORING",
+      "to": "GAME",
+      "rules": [
+        {
+          "action": "accept",
+          "source_address_group": "SCORING_ENGINE",
+          "description": "Scoring can reach game networks"
+        }
+      ]
+    },
+    {
+      "from": "WAN",
+      "to": "GAME",
+      "rules": [
+        {
+          "action": "accept",
+          "protocol": "icmp",
+          "icmp_type": "echo-request",
+          "description": "Allow ping from WAN to GAME"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Groups Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `groups.network` | Object | Named network groups (CIDR notation) |
+| `groups.address` | Object | Named address groups (individual IPs) |
+| `groups.port` | Object | Named port groups (integers or ranges) |
+
+**Zones Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `zones.<name>.interfaces` | Array | Yes | Interfaces belonging to this zone |
+| `zones.<name>.default_action` | String | Yes | `drop` or `reject` (cannot be `accept`) |
+
+**Policy Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `from` | String | Yes | Source zone name |
+| `to` | String | Yes | Destination zone name |
+| `rules` | Array | Yes | List of rules for this zone pair |
+
+**Rule Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `action` | String | Yes | `accept`, `drop`, or `reject` |
+| `protocol` | String | No | `tcp`, `udp`, `icmp`, or `tcp_udp` |
+| `source_address` | String | No | Source IP or CIDR (inline) |
+| `source_address_group` | String | No | Source address group name |
+| `source_network_group` | String | No | Source network group name |
+| `destination_address` | String | No | Destination IP or CIDR (inline) |
+| `destination_address_group` | String | No | Destination address group name |
+| `destination_network_group` | String | No | Destination network group name |
+| `destination_port` | Integer/Array | No | Destination port(s) (inline) |
+| `destination_port_group` | String | No | Destination port group name |
+| `icmp_type` | String | No | ICMP type name (e.g., `echo-request`, `echo-reply`) |
+| `description` | String | No | Rule description |
+
+**Notes:**
+
+- Interfaces not assigned to any zone bypass zone filtering (warning emitted)
+- Management VRF interfaces should be left unzoned for open management access
+- Global state policies (established/related/invalid) are automatically configured
+- NAT happens before firewall; rules match post-NAT (internal) addresses
+- Zone default_action applies when no policy rules match
+
+**Terraform Example:**
+
+```hcl
+FIREWALL_JSON = jsonencode({
+  groups = {
+    network = {
+      GAME     = ["10.64.0.0/10", "10.128.0.0/9"]
+      SCORING  = ["10.62.0.0/16"]
+    }
+    address = {
+      SCORING_ENGINE = ["10.63.0.101"]
+    }
+    port = {
+      WEB = [80, 443]
+    }
+  }
+
+  zones = {
+    WAN = {
+      interfaces     = ["eth0"]
+      default_action = "drop"
+    }
+    GAME = {
+      interfaces     = ["eth1"]
+      default_action = "drop"
+    }
+    SCORING = {
+      interfaces     = ["eth2"]
+      default_action = "drop"
+    }
+  }
+
+  policies = [
+    {
+      from = "GAME"
+      to   = "SCORING"
+      rules = [
+        {
+          action               = "accept"
+          protocol             = "tcp"
+          destination_port_group = "WEB"
+          description          = "Game to scoring web"
+        }
+      ]
+    },
+    {
+      from = "WAN"
+      to   = "SCORING"
+      rules = [
+        {
+          action                    = "accept"
+          destination_address_group = "SCORING_ENGINE"
+          description               = "NAT'd traffic to scoring engine"
+        }
+      ]
+    },
+    {
+      from = "SCORING"
+      to   = "GAME"
+      rules = [
+        {
+          action              = "accept"
+          source_address_group = "SCORING_ENGINE"
+          description         = "Scoring engine can reach game"
+        }
+      ]
+    },
+    {
+      from = "WAN"
+      to   = "GAME"
+      rules = [
+        {
+          action      = "accept"
+          protocol    = "icmp"
+          icmp_type   = "echo-request"
+          description = "Allow ping from WAN"
+        }
+      ]
+    }
+  ]
+})
+```
+
+**Generated VyOS Commands:**
+
+```
+# Global state policies
+set firewall global-options state-policy established action accept
+set firewall global-options state-policy related action accept
+set firewall global-options state-policy invalid action drop
+
+# Groups
+set firewall group network-group GAME network '10.64.0.0/10'
+set firewall group network-group GAME network '10.128.0.0/9'
+set firewall group network-group SCORING network '10.62.0.0/16'
+set firewall group address-group SCORING_ENGINE address '10.63.0.101'
+set firewall group port-group WEB port 80
+set firewall group port-group WEB port 443
+
+# Zones
+set firewall zone WAN interface eth0
+set firewall zone WAN default-action drop
+set firewall zone GAME interface eth1
+set firewall zone GAME default-action drop
+set firewall zone SCORING interface eth2
+set firewall zone SCORING default-action drop
+
+# Policy: GAME to SCORING
+set firewall ipv4 name GAME-to-SCORING default-action drop
+set firewall ipv4 name GAME-to-SCORING rule 100 action accept
+set firewall ipv4 name GAME-to-SCORING rule 100 protocol tcp
+set firewall ipv4 name GAME-to-SCORING rule 100 destination group port-group WEB
+set firewall ipv4 name GAME-to-SCORING rule 100 description 'Game to scoring web'
+set firewall zone SCORING from GAME firewall name GAME-to-SCORING
+
+# Policy: WAN to SCORING
+set firewall ipv4 name WAN-to-SCORING default-action drop
+set firewall ipv4 name WAN-to-SCORING rule 100 action accept
+set firewall ipv4 name WAN-to-SCORING rule 100 destination group address-group SCORING_ENGINE
+set firewall ipv4 name WAN-to-SCORING rule 100 description 'NAT'd traffic to scoring engine'
+set firewall zone SCORING from WAN firewall name WAN-to-SCORING
+
+# Policy: SCORING to GAME
+set firewall ipv4 name SCORING-to-GAME default-action drop
+set firewall ipv4 name SCORING-to-GAME rule 100 action accept
+set firewall ipv4 name SCORING-to-GAME rule 100 source group address-group SCORING_ENGINE
+set firewall ipv4 name SCORING-to-GAME rule 100 description 'Scoring engine can reach game'
+set firewall zone GAME from SCORING firewall name SCORING-to-GAME
+
+# Policy: WAN to GAME (ICMP)
+set firewall ipv4 name WAN-to-GAME default-action drop
+set firewall ipv4 name WAN-to-GAME rule 100 action accept
+set firewall ipv4 name WAN-to-GAME rule 100 protocol icmp
+set firewall ipv4 name WAN-to-GAME rule 100 icmp type-name echo-request
+set firewall ipv4 name WAN-to-GAME rule 100 description 'Allow ping from WAN'
+set firewall zone GAME from WAN firewall name WAN-to-GAME
+```
+
+---
+
+## Escape Hatch Variables
+
+These variables allow arbitrary configuration when structured variables are insufficient.
+
+### START_CONFIG
+
+Raw VyOS commands executed within the configuration transaction.
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `START_CONFIG` | String | VyOS commands (one per line, without `set` prefix optional) |
+
+**Terraform Example:**
+
+```hcl
+START_CONFIG = <<-EOT
+  set system option performance throughput
+  set system syslog global facility all level info
+EOT
+```
+
+**Notes:**
+
+- Commands are executed after all structured configuration
+- Commands run within the same transaction (atomic commit)
+- Use for features not covered by JSON variables
+
+### START_SCRIPT
+
+Shell script executed after VyOS configuration is committed.
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `START_SCRIPT` | String | Shell script content |
+
+**Terraform Example:**
+
+```hcl
+START_SCRIPT = <<-EOT
+  #!/bin/bash
+  echo "Configuration complete at $(date)" >> /var/log/contextualization.log
+EOT
+```
+
+**Notes:**
+
+- Runs after `commit` succeeds
+- Runs as root
+- Use for non-VyOS configuration (custom files, external integrations)
+
+---
+
+## Complete Terraform Example
+
+```hcl
+resource "opennebula_virtual_machine" "router" {
+  name        = "router-01"
+  template_id = var.vyos_template_id
+
+  # eth0 - Management
+  nic {
+    network_id = var.management_network_id
+    ip         = "10.0.1.1"
+  }
+
+  # eth1 - WAN
+  nic {
+    network_id = var.wan_network_id
+    ip         = "203.0.113.10"
+  }
+
+  # eth2 - LAN
+  nic {
+    network_id = var.lan_network_id
+    ip         = "192.168.1.1"
+  }
+
+  context = {
+    # Standard ONE variables
+    NETWORK        = "YES"
+    HOSTNAME       = "router-01"
+    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+
+    # Management interface (in VRF)
+    ETH0_VROUTER_MANAGEMENT = "YES"
+
+    # JSON extensions
+    ROUTES_JSON = jsonencode({
+      static = [
+        { interface = "eth1", destination = "0.0.0.0/0", gateway = "203.0.113.1" }
+      ]
+    })
+
+    OSPF_JSON = jsonencode({
+      enabled = true
+      areas = [
+        { id = "0.0.0.0", networks = ["192.168.0.0/16"] }
+      ]
+      redistribute = ["connected"]
+      passive_interfaces = ["eth1"]
+    })
+
+    NAT_JSON = jsonencode({
+      source = [
+        { outbound_interface = "eth1", source_address = "192.168.0.0/16", translation = "masquerade" }
+      ]
+    })
+
+    DHCP_JSON = jsonencode({
+      pools = [
+        {
+          interface = "eth2"
+          range_start = "192.168.1.100"
+          range_end = "192.168.1.200"
+          gateway = "192.168.1.1"
+          dns = ["192.168.1.1"]
+        }
+      ]
+    })
+  }
+}
+```
+
+## Related Documentation
+
+**Project documentation (mkdocs site):**
+
+- [VyOS Router v3 Project](../../../../docs/docs/projects/backlog/vyos-router-v3/index.md) - Project overview and status
+- [Implementation Plan](../../../../docs/docs/projects/backlog/vyos-router-v3/implementation-plan.md) - Phased implementation approach
+
+**Technical reference:**
+
+- [Design Document](design.md) - Architecture and design decisions
+
+**Current production (Equuleus):**
+
+- [VyOS Operator Guide](../../../../docs/docs/network/vyos_operator_guide.md) - Current Equuleus context variables (different format)

--- a/docs/design.md
+++ b/docs/design.md
@@ -170,7 +170,7 @@ START_SCRIPT="#!/bin/bash\necho 'Custom setup'"
 
 | Feature | Reason |
 |---------|--------|
-| VLAN-tagged interfaces | OpenNebula provides virtual NICs; no qinq support |
+| VLAN-tagged interfaces | OpenNebula provides virtual NICs; no QinQ support |
 | VPN (WireGuard/OpenVPN) | Handled by dedicated VPN infrastructure |
 | Captive portal | Not needed; guest access handled differently |
 | Schedule-based rules | Complexity not justified for current use cases |
@@ -628,9 +628,9 @@ These items are not in v1 scope but are documented for future consideration:
 
 **Project documentation (mkdocs site):**
 
-- [VyOS Router v3 Project](../../../../docs/docs/projects/backlog/vyos-router-v3/index.md) - Project overview and status
-- [Requirements](../../../../docs/docs/projects/backlog/vyos-router-v3/requirements.md) - Detailed requirements analysis
-- [Implementation Plan](../../../../docs/docs/projects/backlog/vyos-router-v3/implementation-plan.md) - Phased implementation approach
+- [VyOS Router v3 Project](../../../../docs/docs/projects/active/vyos-router-v3/index.md) - Project overview and status
+- [Requirements](../../../../docs/docs/projects/active/vyos-router-v3/requirements.md) - Detailed requirements analysis
+- [Implementation Plan](../../../../docs/docs/projects/active/vyos-router-v3/implementation-plan.md) - Phased implementation approach
 
 **Technical reference:**
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,648 @@
+# VyOS Sagitta Contextualization: Design Document
+
+## Overview
+
+This document describes the design for VyOS Sagitta (1.4.x) contextualization scripts
+used with OpenNebula. These scripts configure VyOS routers at boot time based on
+context variables provided by OpenNebula.
+
+## Goals
+
+1. **Stateless configuration**: Router configuration derived entirely from context on every boot
+2. **OpenNebula compatibility**: Support standard ONE network context variables
+3. **Extensibility**: JSON-based schema for advanced features
+4. **Testability**: Python implementation with comprehensive unit tests
+5. **Validation**: Catch configuration errors before applying to VyOS
+
+## Architecture
+
+### Hybrid Approach: Shell + Python
+
+```
+Boot Sequence:
+┌──────────────────────────────────────────────────────────────────────┐
+│ VyOS Boot                                                            │
+│   └─> /config/scripts/vyos-postconfig-bootup.script (shell)          │
+│         ├─> Mount context CD (/dev/sr0 -> /mnt)                      │
+│         ├─> Call: /opt/vyos-onecontext/venv/bin/python               │
+│         │         -m vyos_onecontext /mnt/context.sh                 │
+│         │     ├─> Parse /mnt/context.sh                              │
+│         │     ├─> Validate context (Pydantic models)                 │
+│         │     ├─> Generate VyOS commands                             │
+│         │     └─> Execute via vyatta-cfg-cmd-wrapper                 │
+│         └─> Unmount context CD                                       │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+**Why hybrid?**
+
+- **Shell boot hook**: Simple, reliable, handles mount/unmount
+- **Python in isolated venv**: Type-safe parsing, Pydantic validation, testability
+- **No system Python pollution**: Dependencies isolated from VyOS internals
+
+### Component Responsibilities
+
+| Component | Language | Responsibility |
+|-----------|----------|----------------|
+| `vyos-postconfig-bootup.script` | Shell | Mount context CD, invoke venv Python, unmount |
+| `vyos_onecontext/` | Python | Parse context, validate, generate commands |
+| `vyos_onecontext/wrapper.py` | Python | Execute VyOS CLI commands via wrapper |
+
+## Context Variable Strategy
+
+### OpenNebula Compatibility
+
+We support standard OpenNebula context variables for basic networking:
+
+```bash
+# Standard ONE network variables (per-interface)
+ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+ETH0_GATEWAY="10.0.1.254"
+ETH0_DNS="8.8.8.8"
+ETH0_MTU="1500"
+
+# ONE vrouter management interface
+ETH0_VROUTER_MANAGEMENT="YES"
+
+# ONE NIC alias variables (secondary IPs on same interface)
+ETH0_ALIAS0_IP="10.0.1.2"
+ETH0_ALIAS0_MASK="255.255.255.0"
+
+# Standard ONE identity
+HOSTNAME="router-01"
+SSH_PUBLIC_KEY="ssh-rsa AAAA... user@host"
+```
+
+This provides compatibility with OpenNebula's network contextualization and vrouter conventions.
+
+### NIC Aliases (Secondary IPs)
+
+OpenNebula supports NIC aliases for assigning multiple IPs to a single interface. This is used
+for 1:1 NAT scenarios where the router needs additional public IPs.
+
+**How it works:**
+
+1. Terraform declares `nic_alias` blocks referencing a parent NIC
+2. OpenNebula manages the IP lease from the virtual network
+3. Context receives `ETH{n}_ALIAS{m}_IP`, `ETH{n}_ALIAS{m}_MASK`, etc.
+4. Contextualization adds secondary addresses to the interface
+5. NAT rules can reference these alias IPs for bidirectional NAT
+
+**Terraform example:**
+
+```hcl
+nic {
+  name       = "wan"
+  network_id = var.wan_network_id
+  ip         = "129.244.246.64"
+}
+
+nic_alias {
+  parent     = "wan"
+  network_id = var.wan_network_id
+  ip         = "129.244.246.66"  # ONE manages this lease
+}
+```
+
+**Context variables:**
+
+```bash
+ETH0_IP="129.244.246.64"
+ETH0_MASK="255.255.255.0"
+ETH0_ALIAS0_IP="129.244.246.66"
+ETH0_ALIAS0_MASK="255.255.255.0"
+```
+
+**Note:** There is a known OpenNebula bug where `ETH{n}_ALIAS{m}_MASK` may be empty. The
+contextualization script falls back to the parent interface's mask when this occurs.
+
+### JSON Extensions
+
+For advanced features beyond ONE's standard variables, we use JSON-encoded context variables:
+
+```bash
+# JSON-encoded advanced configuration
+ROUTES_JSON='{"static":[{"interface":"eth1","destination":"0.0.0.0/0","gateway":"10.63.255.1"}]}'
+OSPF_JSON='{"enabled":true,"areas":[{"id":"0.0.0.0","networks":["10.0.0.0/8"]}]}'
+```
+
+**Why JSON?**
+
+- Self-documenting field names (vs positional space-delimited)
+- Native parsing in Python (`json.loads()`)
+- Terraform's `jsonencode()` provides structure validation
+- Handles complex nested configuration cleanly
+
+### Escape Hatches
+
+For configuration not covered by structured variables:
+
+```bash
+# Raw VyOS commands (one per line)
+START_CONFIG="set system option performance throughput"
+
+# Shell script executed after VyOS config commit
+START_SCRIPT="#!/bin/bash\necho 'Custom setup'"
+```
+
+## Feature Scope
+
+### v1 Features (In Scope)
+
+| Feature | Context Source | Status |
+|---------|----------------|--------|
+| Interface configuration | `ETHx_IP`, `ETHx_MASK`, etc. | Designed |
+| Management VRF | `ETHx_VROUTER_MANAGEMENT` | Designed |
+| Hostname | `HOSTNAME` | Designed |
+| SSH keys | `SSH_PUBLIC_KEY` | Designed |
+| Static routes | `ROUTES_JSON` | Designed |
+| OSPF | `OSPF_JSON` | Designed |
+| DHCP server | `DHCP_JSON` | Designed |
+| Source NAT (masquerade) | `NAT_JSON` | Designed |
+| Destination NAT (port forwards) | `NAT_JSON` | Designed |
+| 1:1 NAT (bidirectional) | `NAT_JSON` + `ETHx_ALIASy_IP` | Designed |
+| Custom commands | `START_CONFIG` | Designed |
+| Custom scripts | `START_SCRIPT` | Designed |
+| Zone-based firewall | `FIREWALL_JSON` | Designed |
+
+### Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| VLAN-tagged interfaces | OpenNebula provides virtual NICs; no qinq support |
+| VPN (WireGuard/OpenVPN) | Handled by dedicated VPN infrastructure |
+| Captive portal | Not needed; guest access handled differently |
+| Schedule-based rules | Complexity not justified for current use cases |
+| Scoring relay NAT | Requires VRF + policy routing redesign |
+| HA (keepalived/VRRP) | Future enhancement if needed |
+| IPv6 | Not currently used in infrastructure |
+
+## Management VRF
+
+Interfaces marked with `ETHx_VROUTER_MANAGEMENT="YES"` are placed in a management VRF
+for out-of-band network isolation.
+
+**Behavior:**
+
+- Management interfaces use VRF `management` (routing table 100)
+- SSH service binds to management VRF
+- Multiple interfaces can be in management VRF (valid for redundancy)
+- If no management interface specified, SSH is globally accessible
+
+```python
+# Example: Finding management interfaces
+mgmt_interfaces = [
+    iface for iface in interfaces
+    if context.get(f"{iface.upper()}_VROUTER_MANAGEMENT") == "YES"
+]
+```
+
+## Validation
+
+Pydantic models provide automatic validation with clear error messages:
+
+```python
+from pydantic import BaseModel, field_validator
+from ipaddress import ip_network, ip_address
+
+class Route(BaseModel):
+    interface: str
+    destination: str
+    gateway: str | None = None
+    distance: int = 1
+    vrf: str | None = None
+
+    @field_validator('destination')
+    @classmethod
+    def validate_destination(cls, v: str) -> str:
+        ip_network(v, strict=False)  # Raises ValueError if invalid
+        return v
+
+    @field_validator('gateway')
+    @classmethod
+    def validate_gateway(cls, v: str | None) -> str | None:
+        if v is not None:
+            ip_address(v)  # Raises ValueError if invalid
+        return v
+```
+
+**Validation types:**
+
+| Validation | How |
+|------------|-----|
+| IP address format | `ipaddress.ip_address()` in field validator |
+| CIDR notation | `ipaddress.ip_network()` in field validator |
+| Required fields | Pydantic enforces non-optional fields |
+| Type coercion | Pydantic handles string-to-int, etc. |
+| Nested objects | Pydantic validates recursively |
+
+**Error handling:**
+
+Validation errors are logged with context and cause contextualization to fail fast,
+rather than producing cryptic errors at VyOS commit time:
+
+```
+ERROR: Validation failed for ROUTES_JSON:
+  static.0.destination: '10.0.0.0/33' is not a valid CIDR network
+  static.1.gateway: 'not-an-ip' is not a valid IPv4 address
+```
+
+## VyOS Command Execution
+
+Commands are executed through VyOS's configuration wrapper:
+
+```python
+WRAPPER = "/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper"
+
+def execute_commands(commands: list[str]) -> None:
+    subprocess.run([WRAPPER, "begin"], check=True)
+    try:
+        for cmd in commands:
+            subprocess.run([WRAPPER] + cmd.split(), check=True)
+        subprocess.run([WRAPPER, "commit"], check=True)
+    finally:
+        subprocess.run([WRAPPER, "end"], check=True)
+```
+
+All commands are executed within a single transaction. If any command fails,
+the entire configuration is rolled back.
+
+## Testing Strategy
+
+### Unit Tests (No VyOS Required)
+
+The Python implementation separates parsing/generation from execution:
+
+```python
+import pytest
+from vyos_onecontext.models import Route, RoutesConfig
+from vyos_onecontext.generators.routing import generate_route_commands
+
+def test_parse_routes():
+    """Test JSON parsing into Pydantic models."""
+    json_data = '{"static":[{"interface":"eth1","destination":"0.0.0.0/0","gateway":"10.1.1.1"}]}'
+    config = RoutesConfig.model_validate_json(json_data)
+
+    assert len(config.static) == 1
+    assert config.static[0].interface == "eth1"
+    assert config.static[0].destination == "0.0.0.0/0"
+    assert config.static[0].gateway == "10.1.1.1"
+
+def test_route_validation_rejects_invalid_cidr():
+    """Test that invalid CIDR is rejected."""
+    with pytest.raises(ValueError, match="not a valid"):
+        Route(interface="eth1", destination="10.0.0.0/33", gateway="10.1.1.1")
+
+def test_generate_route_commands():
+    """Test VyOS command generation."""
+    route = Route(interface="eth1", destination="0.0.0.0/0", gateway="10.1.1.1")
+    commands = generate_route_commands([route])
+
+    assert "set protocols static route 0.0.0.0/0 next-hop 10.1.1.1" in commands
+```
+
+### Test Fixtures
+
+Common fixtures in `conftest.py`:
+
+```python
+import pytest
+
+@pytest.fixture
+def sample_context() -> dict[str, str]:
+    """Minimal valid context for testing."""
+    return {
+        "HOSTNAME": "test-router",
+        "ETH0_IP": "10.0.1.1",
+        "ETH0_MASK": "255.255.255.0",
+        "ETH0_VROUTER_MANAGEMENT": "YES",
+    }
+
+@pytest.fixture
+def full_context(sample_context) -> dict[str, str]:
+    """Full context with all JSON extensions."""
+    return {
+        **sample_context,
+        "ROUTES_JSON": '{"static":[{"interface":"eth1","destination":"0.0.0.0/0","gateway":"10.0.1.254"}]}',
+        "OSPF_JSON": '{"enabled":true,"areas":[{"id":"0.0.0.0","networks":["10.0.0.0/8"]}]}',
+    }
+```
+
+### Integration Tests (VyOS VM)
+
+Full integration tests run in a VyOS VM with mock context:
+
+1. Create context ISO with test variables
+2. Boot VyOS VM with context attached
+3. Verify resulting configuration matches expected
+
+These are marked with `@pytest.mark.integration` and skipped in normal CI runs.
+
+## Directory Structure
+
+Following the standard uv/hatchling project layout used across SWCCDC Python projects:
+
+```
+vyos-onecontext/
+├── pyproject.toml                # Project metadata, dependencies, tool config
+├── uv.lock                       # Pinned dependencies (generated)
+├── justfile                      # Task automation (test, lint, fmt)
+├── README.md
+├── docs/
+│   ├── design.md                 # This document
+│   └── context-reference.md      # Context variable reference
+├── src/
+│   └── vyos_onecontext/
+│       ├── __init__.py
+│       ├── __main__.py           # Entry point (python -m vyos_onecontext)
+│       ├── context.py            # Context parsing
+│       ├── models.py             # Pydantic models for config objects
+│       ├── generators/
+│       │   ├── __init__.py
+│       │   ├── interfaces.py     # Interface config generation
+│       │   ├── routing.py        # Static routes + OSPF
+│       │   ├── services.py       # DHCP, SSH
+│       │   └── nat.py            # NAT rules
+│       └── wrapper.py            # VyOS CLI wrapper
+├── tests/
+│   ├── conftest.py               # Shared pytest fixtures
+│   ├── unit/
+│   │   ├── test_context.py
+│   │   ├── test_validators.py
+│   │   └── test_generators/
+│   │       ├── test_interfaces.py
+│   │       ├── test_routing.py
+│   │       └── ...
+│   └── integration/              # Tests requiring VyOS (future)
+│       └── conftest.py
+├── scripts/
+│   └── vyos-postconfig-bootup.script  # Shell boot hook (installed to VyOS)
+└── .github/
+    └── ...                       # CI workflows
+```
+
+## Runtime Considerations
+
+### Development Environment
+
+Standard uv workflow:
+
+```bash
+uv sync                    # Install dependencies
+uv run pytest              # Run tests
+uv run ruff check .        # Lint
+uv build                   # Build wheel for deployment
+```
+
+### VyOS Runtime
+
+The Python code runs on VyOS at boot time in an **isolated virtualenv** to avoid
+conflicts with VyOS's system Python packages.
+
+**Installation layout on VyOS:**
+
+```
+/opt/vyos-onecontext/
+└── venv/
+    ├── bin/
+    │   └── python          # Isolated Python interpreter
+    └── lib/
+        └── python3.x/
+            └── site-packages/
+                ├── vyos_onecontext/
+                └── pydantic/
+```
+
+**Dependencies:**
+
+- `pydantic` - Data validation and settings management
+- Standard library: `ipaddress`, `json`, `subprocess`, `logging`
+
+### Packer Build Process
+
+The virtualenv is created during image build:
+
+```hcl
+# 1. Copy the wheel built by CI
+provisioner "file" {
+  source      = "dist/vyos_onecontext-${var.version}-py3-none-any.whl"
+  destination = "/tmp/vyos_onecontext.whl"
+}
+
+# 2. Create isolated venv and install
+provisioner "shell" {
+  inline = [
+    "python3 -m venv /opt/vyos-onecontext/venv",
+    "/opt/vyos-onecontext/venv/bin/pip install --no-cache-dir /tmp/vyos_onecontext.whl",
+    "rm /tmp/vyos_onecontext.whl"
+  ]
+}
+
+# 3. Install boot hook
+provisioner "file" {
+  source      = "scripts/vyos-postconfig-bootup.script"
+  destination = "/tmp/vyos-postconfig-bootup.script"
+}
+
+provisioner "shell" {
+  inline = [
+    "mv /tmp/vyos-postconfig-bootup.script /config/scripts/",
+    "chmod 755 /config/scripts/vyos-postconfig-bootup.script"
+  ]
+}
+```
+
+### Boot Script
+
+The shell boot hook invokes the venv Python:
+
+```bash
+#!/bin/sh
+# Mount OpenNebula context CD
+mount -t iso9660 /dev/sr0 /mnt 2>/dev/null
+
+if [ $? -eq 0 ]; then
+    # Run contextualization from isolated venv
+    /opt/vyos-onecontext/venv/bin/python -m vyos_onecontext /mnt/context.sh
+    umount /mnt
+fi
+```
+
+### Benefits of Isolated Venv
+
+| Benefit | Description |
+|---------|-------------|
+| No conflicts | VyOS system packages remain untouched |
+| Pydantic validation | Clean data validation with good error messages |
+| Reproducible | Same wheel + dependencies every build |
+| Testable | Exact same code runs in dev and production |
+
+## Sagitta Syntax Notes
+
+VyOS 1.4 (Sagitta) has syntax changes from 1.3 (Equuleus):
+
+| Feature | Equuleus | Sagitta |
+|---------|----------|---------|
+| NAT interface | `outbound-interface eth0` | `outbound-interface name 'eth0'` |
+| Static route | `set protocols static interface-route ...` | `set protocols static route X interface Y` |
+| Firewall zones | `zone-policy zone` | `firewall zone` |
+| OSPF network | `area X network Y` | `area X network Y` (unchanged) |
+
+The generators produce Sagitta-compatible syntax.
+
+## Firewall Design
+
+VyOS Sagitta uses nftables and supports zone-based firewalling. Our contextualization
+uses zones for coarse inter-network policy while leaving management VRF unfiltered.
+
+### Architecture
+
+**Zone-based approach:**
+- Zones group interfaces by security level
+- Each zone has a `default_action` (drop or reject)
+- Policies define allowed traffic between zone pairs
+- Rules within policies can filter by address, port, protocol
+
+**Key behaviors:**
+- NAT (DNAT) happens before firewall → rules match post-NAT (internal) addresses
+- Global state policies handle established/related/invalid traffic
+- Interfaces not in any zone bypass zone filtering entirely
+- Warning emitted for unzoned interfaces (intentional for management VRF)
+
+### Interaction with VRF
+
+There is a known VyOS bug (T2251) where zone-based firewall + VRF has issues with
+interface detection. Our approach avoids this by:
+
+1. Leaving management VRF interfaces out of zones entirely
+2. Management traffic flows freely (no zone filtering)
+3. Only non-VRF interfaces participate in zone-based filtering
+
+This sidesteps the bug and matches the intent of keeping management open.
+
+### Packet Flow
+
+```
+Inbound packet arrives
+    │
+    ▼
+┌─────────────────┐
+│   Prerouting    │ ◄── DNAT (port forwards, 1:1 NAT) happens here
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  Routing decision│
+└────────┬────────┘
+         │
+    ┌────┴────┐
+    │         │
+    ▼         ▼
+┌───────┐  ┌───────┐
+│ Input │  │Forward│ ◄── Zone policies evaluate here (post-NAT addresses)
+│(local)│  │(transit)│
+└───────┘  └───┬───┘
+               │
+               ▼
+┌─────────────────┐
+│   Postrouting   │ ◄── SNAT (masquerade, 1:1 outbound) happens here
+└─────────────────┘
+```
+
+### Rule Granularity
+
+Within a zone-to-zone policy, rules can have varying specificity:
+
+| Pattern | Source | Destination | Use Case |
+|---------|--------|-------------|----------|
+| zone-to-zone | (any) | (any) | GAME can reach SCORING on web ports |
+| zone-to-host | (any) | specific IP/group | GAME can reach scoring engine |
+| host-to-zone | specific IP/group | (any) | Red team server can reach GAME |
+| host-to-host | specific IP/group | specific IP/group | Admin host can SSH to specific server |
+
+### Rule Auto-Numbering
+
+The generator auto-numbers rules starting at 100, incrementing by 100 (100, 200, 300...).
+
+This leaves room for operators to inject manual rules via `START_CONFIG`:
+- Rules 1-99: Reserved for manual "early" rules (highest priority)
+- Rules 100+: Auto-generated from FIREWALL_JSON
+- Rules 900+: Reserved for manual "late" rules (before default-action)
+
+**TODO:** Finalize numbering scheme during implementation. Consider whether to expose
+rule priority in the JSON schema or keep it implicit.
+
+### Generated Configuration
+
+The generator produces:
+
+1. **Global state policies:**
+```
+set firewall global-options state-policy established action accept
+set firewall global-options state-policy related action accept
+set firewall global-options state-policy invalid action drop
+```
+
+2. **Firewall groups:**
+```
+set firewall group network-group GAME network '10.64.0.0/10'
+set firewall group port-group WEB port 80
+set firewall group port-group WEB port 443
+```
+
+3. **Zone definitions:**
+```
+set firewall zone WAN interface eth0
+set firewall zone WAN default-action drop
+set firewall zone GAME interface eth1
+set firewall zone GAME default-action drop
+```
+
+4. **Named rulesets and zone policies:**
+```
+set firewall ipv4 name WAN-to-GAME default-action drop
+set firewall ipv4 name WAN-to-GAME rule 100 action accept
+set firewall ipv4 name WAN-to-GAME rule 100 destination group network-group SCORING_ENGINE
+set firewall ipv4 name WAN-to-GAME rule 100 description "NAT'd traffic to scoring"
+
+set firewall zone GAME from WAN firewall name WAN-to-GAME
+```
+
+### Future Enhancements
+
+These items are not in v1 scope but are documented for future consideration:
+
+1. **LOCAL zone support**: Traffic to/from the router itself (SSH, OSPF, BGP, DNS services).
+   Currently, services on the router are accessible if the interface is unzoned (management VRF)
+   or via global state policies for return traffic. Explicit LOCAL zone policies may be needed
+   for more complex setups.
+
+2. **Rule logging**: VyOS supports per-rule logging with configurable prefixes. Could add
+   `log: true` and `log_prefix: "..."` fields to rule schema.
+
+3. **Interface groups in rules**: VyOS allows matching interface-groups directly in rules
+   (not just in zones). Could add `source_interface_group` / `destination_interface_group`.
+
+## Related Documentation
+
+**Project documentation (mkdocs site):**
+
+- [VyOS Router v3 Project](../../../../docs/docs/projects/backlog/vyos-router-v3/index.md) - Project overview and status
+- [Requirements](../../../../docs/docs/projects/backlog/vyos-router-v3/requirements.md) - Detailed requirements analysis
+- [Implementation Plan](../../../../docs/docs/projects/backlog/vyos-router-v3/implementation-plan.md) - Phased implementation approach
+
+**Technical reference:**
+
+- [Context Variable Reference](context-reference.md) - Complete schema for all context variables
+
+**Current production (Equuleus):**
+
+- [VyOS Operator Guide](../../../../docs/docs/network/vyos_operator_guide.md) - Current Equuleus deployment guide
+- [VyOS Developer Guide](../../../../docs/docs/network/vyos_developer_guide.md) - Current Equuleus build pipeline
+
+**External:**
+
+- [VyOS 1.4 Documentation](https://docs.vyos.io/en/sagitta/)
+- [OpenNebula Contextualization](https://docs.opennebula.io/6.8/management_and_operations/references/template.html#context-section)
+- [VyOS Cloud-Init](https://docs.vyos.io/en/sagitta/automation/cloud-init.html)


### PR DESCRIPTION
## Summary

Complete design phase for VyOS Sagitta contextualization:

- **Architecture**: Hybrid shell + Python with Pydantic validation
- **Context variables**: JSON schemas for routes, OSPF, DHCP, NAT, firewall
- **Management VRF**: Isolated out-of-band management interface
- **Zone-based firewall**: Groups, zones, policies with state tracking
- **NIC aliases**: Secondary IPs for 1:1 NAT scenarios

## Files

- `docs/design.md` - Architecture and design decisions
- `docs/context-reference.md` - Complete JSON schema reference
- `README.md` - Expanded with quick start, features, dev setup

## Related

- [VyOS Router v3 Project](https://github.com/SouthwestCCDC/deployment/tree/george/vyos-v3-project-docs/docs/docs/projects/backlog/vyos-router-v3)
- [Implementation Plan](https://github.com/SouthwestCCDC/deployment/blob/george/vyos-v3-project-docs/docs/docs/projects/backlog/vyos-router-v3/implementation-plan.md)

---

🤖 Generated with [Claude Code](https://claude.ai/code)