### PR TITLE
Implement context parser (Phase 0.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Type checking
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Ruff
+.ruff_cache/

--- a/src/vyos_onecontext/__init__.py
+++ b/src/vyos_onecontext/__init__.py
@@ -1,3 +1,7 @@
 """VyOS Sagitta contextualization for OpenNebula."""
 
+from vyos_onecontext.parser import ContextParser, parse_context
+
 __version__ = "0.1.0"
+
+__all__ = ["ContextParser", "parse_context", "__version__"]

--- a/src/vyos_onecontext/parser.py
+++ b/src/vyos_onecontext/parser.py
@@ -1,0 +1,369 @@
+"""Context file parser for OpenNebula contextualization.
+
+This module parses the OpenNebula context file (/var/run/one-context/one_env)
+and converts shell variable assignments into validated Pydantic models.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+from vyos_onecontext.models.config import OnecontextMode, RouterConfig
+from vyos_onecontext.models.dhcp import DhcpConfig
+from vyos_onecontext.models.firewall import FirewallConfig
+from vyos_onecontext.models.interface import AliasConfig, InterfaceConfig
+from vyos_onecontext.models.nat import NatConfig
+from vyos_onecontext.models.routing import OspfConfig, RoutesConfig
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class ContextParser:
+    """Parser for OpenNebula context files.
+
+    Reads shell variable assignments from the context file and converts them
+    into structured configuration objects.
+    """
+
+    def __init__(self, path: str = "/var/run/one-context/one_env") -> None:
+        """Initialize the parser.
+
+        Args:
+            path: Path to the context file (default: /var/run/one-context/one_env)
+        """
+        self.path = Path(path)
+        self.variables: dict[str, str] = {}
+
+    def parse(self) -> RouterConfig:
+        """Parse the context file and return a validated RouterConfig.
+
+        Returns:
+            RouterConfig: Validated router configuration
+
+        Raises:
+            FileNotFoundError: If the context file does not exist
+            ValueError: If the context file is malformed or contains invalid data
+        """
+        self._read_variables()
+
+        # Parse each configuration section
+        interfaces = self._parse_interfaces()
+        aliases = self._parse_aliases(interfaces)
+        routes = self._parse_routes()
+        ospf = self._parse_ospf()
+        dhcp = self._parse_dhcp()
+        nat = self._parse_nat()
+        firewall = self._parse_firewall()
+
+        # Parse operational variables
+        hostname = self.variables.get("HOSTNAME")
+        ssh_public_key = self.variables.get("SSH_PUBLIC_KEY")
+        onecontext_mode = self._parse_onecontext_mode()
+
+        # Parse escape hatches
+        start_config = self.variables.get("START_CONFIG")
+        start_script = self.variables.get("START_SCRIPT")
+
+        # Build and validate complete configuration
+        return RouterConfig(
+            hostname=hostname,
+            ssh_public_key=ssh_public_key,
+            onecontext_mode=onecontext_mode,
+            interfaces=interfaces,
+            aliases=aliases,
+            routes=routes,
+            ospf=ospf,
+            dhcp=dhcp,
+            nat=nat,
+            firewall=firewall,
+            start_config=start_config,
+            start_script=start_script,
+        )
+
+    def _read_variables(self) -> None:
+        """Read and parse shell variable assignments from the context file.
+
+        The file format is shell variable assignments:
+            VAR_NAME="value"
+            MULTILINE_VAR="line1
+            line2"
+
+        Raises:
+            FileNotFoundError: If the context file does not exist
+            ValueError: If the file is malformed
+        """
+        if not self.path.exists():
+            raise FileNotFoundError(f"Context file not found: {self.path}")
+
+        content = self.path.read_text()
+        self.variables = self._parse_shell_variables(content)
+
+    def _parse_shell_variables(self, content: str) -> dict[str, str]:
+        """Parse shell variable assignments into a dictionary.
+
+        Args:
+            content: Shell script content with variable assignments
+
+        Returns:
+            Dictionary mapping variable names to values
+        """
+        variables: dict[str, str] = {}
+        lines = content.splitlines()
+        i = 0
+
+        while i < len(lines):
+            line = lines[i].strip()
+
+            # Skip empty lines and comments
+            if not line or line.startswith("#"):
+                i += 1
+                continue
+
+            # Match variable assignment: VAR="value" or VAR='value'
+            match = re.match(r'^([A-Z_][A-Z0-9_]*)=(["\']?)(.*)', line)
+            if not match:
+                i += 1
+                continue
+
+            var_name = match.group(1)
+            quote = match.group(2)
+            rest = match.group(3)
+
+            if not quote:
+                # Unquoted value (ends at first whitespace)
+                value = rest.split()[0] if rest else ""
+                variables[var_name] = value
+                i += 1
+            else:
+                # Quoted value - may span multiple lines
+                value_parts = []
+                current_line = rest
+
+                # Check if quote closes on same line
+                if quote in current_line:
+                    end_idx = current_line.index(quote)
+                    value_parts.append(current_line[:end_idx])
+                    variables[var_name] = "".join(value_parts)
+                    i += 1
+                else:
+                    # Multi-line value
+                    value_parts.append(current_line)
+                    i += 1
+
+                    # Continue reading until we find the closing quote
+                    while i < len(lines):
+                        current_line = lines[i]
+                        if quote in current_line:
+                            end_idx = current_line.index(quote)
+                            value_parts.append("\n")
+                            value_parts.append(current_line[:end_idx])
+                            variables[var_name] = "".join(value_parts)
+                            i += 1
+                            break
+                        else:
+                            value_parts.append("\n")
+                            value_parts.append(current_line)
+                            i += 1
+
+        return variables
+
+    def _parse_interfaces(self) -> list[InterfaceConfig]:
+        """Parse ETHx_* variables into InterfaceConfig objects.
+
+        Returns:
+            List of interface configurations
+        """
+        interfaces: list[InterfaceConfig] = []
+
+        # Find all ETHx interfaces by looking for ETHx_IP variables
+        eth_numbers = set()
+        for var_name in self.variables:
+            match = re.match(r"^ETH(\d+)_IP$", var_name)
+            if match:
+                eth_numbers.add(int(match.group(1)))
+
+        # Parse each interface
+        for eth_num in sorted(eth_numbers):
+            prefix = f"ETH{eth_num}"
+            ip = self.variables.get(f"{prefix}_IP")
+
+            # Skip if no IP (shouldn't happen given how we found it, but be safe)
+            if not ip:
+                continue
+
+            mask = self.variables.get(f"{prefix}_MASK")
+            if not mask:
+                raise ValueError(f"Interface {prefix} has IP but no MASK")
+
+            gateway = self.variables.get(f"{prefix}_GATEWAY")
+            dns = self.variables.get(f"{prefix}_DNS")
+            mtu_str = self.variables.get(f"{prefix}_MTU")
+            management_str = self.variables.get(f"{prefix}_VROUTER_MANAGEMENT")
+
+            # Parse MTU
+            mtu = int(mtu_str) if mtu_str else None
+
+            # Parse management flag
+            management = management_str == "YES" if management_str else False
+
+            interfaces.append(
+                InterfaceConfig(
+                    name=f"eth{eth_num}",
+                    ip=ip,  # type: ignore[arg-type]  # Pydantic converts str to IPv4Address
+                    mask=mask,
+                    gateway=gateway,  # type: ignore[arg-type]  # Pydantic converts str to IPv4Address
+                    dns=dns,  # type: ignore[arg-type]  # Pydantic converts str to IPv4Address
+                    mtu=mtu,
+                    management=management,
+                )
+            )
+
+        return interfaces
+
+    def _parse_aliases(self, interfaces: list[InterfaceConfig]) -> list[AliasConfig]:
+        """Parse ETHx_ALIASy_* variables into AliasConfig objects.
+
+        Args:
+            interfaces: List of parsed interfaces (for mask fallback)
+
+        Returns:
+            List of alias configurations
+        """
+        aliases: list[AliasConfig] = []
+
+        # Find all aliases by looking for ETHx_ALIASy_IP variables
+        alias_pattern = re.compile(r"^ETH(\d+)_ALIAS(\d+)_IP$")
+        alias_keys = set()
+
+        for var_name in self.variables:
+            match = alias_pattern.match(var_name)
+            if match:
+                eth_num = int(match.group(1))
+                alias_num = int(match.group(2))
+                alias_keys.add((eth_num, alias_num))
+
+        # Parse each alias
+        for eth_num, alias_num in sorted(alias_keys):
+            interface_name = f"eth{eth_num}"
+            prefix = f"ETH{eth_num}_ALIAS{alias_num}"
+
+            ip = self.variables.get(f"{prefix}_IP")
+            if not ip:
+                continue
+
+            # Mask may be empty due to OpenNebula bug
+            mask = self.variables.get(f"{prefix}_MASK")
+            if mask == "":
+                mask = None
+
+            # If no mask, we'll let the model handle the fallback using the parent interface mask
+            # But we need to ensure the mask is None, not empty string
+            aliases.append(
+                AliasConfig(
+                    interface=interface_name,
+                    ip=ip,  # type: ignore[arg-type]  # Pydantic converts str to IPv4Address
+                    mask=mask,
+                )
+            )
+
+        return aliases
+
+    def _parse_onecontext_mode(self) -> OnecontextMode:
+        """Parse ONECONTEXT_MODE variable.
+
+        Returns:
+            OnecontextMode enum value (defaults to STATELESS)
+        """
+        mode_str = self.variables.get("ONECONTEXT_MODE", "stateless").lower()
+        try:
+            return OnecontextMode(mode_str)
+        except ValueError:
+            # Default to stateless if invalid value
+            return OnecontextMode.STATELESS
+
+    def _parse_json_variable(self, var_name: str, model_class: type[T]) -> T | None:
+        """Parse a JSON variable and validate with a Pydantic model.
+
+        Args:
+            var_name: Name of the variable containing JSON
+            model_class: Pydantic model class to validate against
+
+        Returns:
+            Validated model instance or None if variable not present
+
+        Raises:
+            ValueError: If JSON is malformed or validation fails
+        """
+        json_str = self.variables.get(var_name)
+        if not json_str:
+            return None
+
+        try:
+            data = json.loads(json_str)
+            return model_class.model_validate(data)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON in {var_name}: {e}") from e
+        except Exception as e:
+            raise ValueError(f"Validation error in {var_name}: {e}") from e
+
+    def _parse_routes(self) -> RoutesConfig | None:
+        """Parse ROUTES_JSON variable.
+
+        Returns:
+            RoutesConfig or None if not present
+        """
+        return self._parse_json_variable("ROUTES_JSON", RoutesConfig)
+
+    def _parse_ospf(self) -> OspfConfig | None:
+        """Parse OSPF_JSON variable.
+
+        Returns:
+            OspfConfig or None if not present
+        """
+        return self._parse_json_variable("OSPF_JSON", OspfConfig)
+
+    def _parse_dhcp(self) -> DhcpConfig | None:
+        """Parse DHCP_JSON variable.
+
+        Returns:
+            DhcpConfig or None if not present
+        """
+        return self._parse_json_variable("DHCP_JSON", DhcpConfig)
+
+    def _parse_nat(self) -> NatConfig | None:
+        """Parse NAT_JSON variable.
+
+        Returns:
+            NatConfig or None if not present
+        """
+        return self._parse_json_variable("NAT_JSON", NatConfig)
+
+    def _parse_firewall(self) -> FirewallConfig | None:
+        """Parse FIREWALL_JSON variable.
+
+        Returns:
+            FirewallConfig or None if not present
+        """
+        return self._parse_json_variable("FIREWALL_JSON", FirewallConfig)
+
+
+def parse_context(path: str = "/var/run/one-context/one_env") -> RouterConfig:
+    """Parse ONE context file and return validated RouterConfig.
+
+    This is a convenience function that creates a ContextParser and calls parse().
+
+    Args:
+        path: Path to the context file (default: /var/run/one-context/one_env)
+
+    Returns:
+        RouterConfig: Validated router configuration
+
+    Raises:
+        FileNotFoundError: If the context file does not exist
+        ValueError: If the context file is malformed or contains invalid data
+    """
+    parser = ContextParser(path)
+    return parser.parse()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,574 @@
+"""Tests for context file parser."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vyos_onecontext.models import OnecontextMode
+from vyos_onecontext.parser import ContextParser, parse_context
+
+
+class TestShellVariableParsing:
+    """Tests for shell variable parsing."""
+
+    def test_simple_variable(self, tmp_path: Path) -> None:
+        """Test parsing simple quoted variable."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text('HOSTNAME="router-01"\n')
+
+        parser = ContextParser(str(context_file))
+        parser._read_variables()
+
+        assert parser.variables["HOSTNAME"] == "router-01"
+
+    def test_unquoted_variable(self, tmp_path: Path) -> None:
+        """Test parsing unquoted variable."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text("ETH0_MTU=1500\n")
+
+        parser = ContextParser(str(context_file))
+        parser._read_variables()
+
+        assert parser.variables["ETH0_MTU"] == "1500"
+
+    def test_multiline_variable(self, tmp_path: Path) -> None:
+        """Test parsing multiline variable."""
+        context_file = tmp_path / "one_env"
+        content = """SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAA...
+line2
+line3"
+"""
+        context_file.write_text(content)
+
+        parser = ContextParser(str(context_file))
+        parser._read_variables()
+
+        assert "SSH_PUBLIC_KEY" in parser.variables
+        assert "line2" in parser.variables["SSH_PUBLIC_KEY"]
+        assert "line3" in parser.variables["SSH_PUBLIC_KEY"]
+
+    def test_empty_variable(self, tmp_path: Path) -> None:
+        """Test parsing empty variable."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text('ETH0_ALIAS0_MASK=""\n')
+
+        parser = ContextParser(str(context_file))
+        parser._read_variables()
+
+        assert parser.variables["ETH0_ALIAS0_MASK"] == ""
+
+    def test_comment_lines(self, tmp_path: Path) -> None:
+        """Test that comment lines are skipped."""
+        context_file = tmp_path / "one_env"
+        content = """# This is a comment
+HOSTNAME="router-01"
+# Another comment
+ETH0_IP="10.0.1.1"
+"""
+        context_file.write_text(content)
+
+        parser = ContextParser(str(context_file))
+        parser._read_variables()
+
+        assert "HOSTNAME" in parser.variables
+        assert "ETH0_IP" in parser.variables
+        assert len(parser.variables) == 2
+
+    def test_mixed_quotes(self, tmp_path: Path) -> None:
+        """Test parsing variables with different quote styles."""
+        context_file = tmp_path / "one_env"
+        content = """VAR1="double"
+VAR2='single'
+"""
+        context_file.write_text(content)
+
+        parser = ContextParser(str(context_file))
+        parser._read_variables()
+
+        assert parser.variables["VAR1"] == "double"
+        assert parser.variables["VAR2"] == "single"
+
+
+class TestInterfaceParsing:
+    """Tests for interface parsing."""
+
+    def test_single_interface(self, tmp_path: Path) -> None:
+        """Test parsing single interface."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+ETH0_GATEWAY="10.0.1.254"
+ETH0_DNS="8.8.8.8"
+ETH0_MTU="1500"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 1
+        iface = config.interfaces[0]
+        assert iface.name == "eth0"
+        assert str(iface.ip) == "10.0.1.1"
+        assert iface.mask == "255.255.255.0"
+        assert str(iface.gateway) == "10.0.1.254"
+        assert str(iface.dns) == "8.8.8.8"
+        assert iface.mtu == 1500
+        assert iface.management is False
+
+    def test_management_interface(self, tmp_path: Path) -> None:
+        """Test parsing interface with management flag."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+ETH0_VROUTER_MANAGEMENT="YES"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 1
+        assert config.interfaces[0].management is True
+
+    def test_multiple_interfaces(self, tmp_path: Path) -> None:
+        """Test parsing multiple interfaces."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH2_IP="172.16.0.1"
+ETH2_MASK="255.255.0.0"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 3
+        assert config.interfaces[0].name == "eth0"
+        assert config.interfaces[1].name == "eth1"
+        assert config.interfaces[2].name == "eth2"
+
+    def test_interface_without_mask_raises_error(self, tmp_path: Path) -> None:
+        """Test that interface without mask raises error."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.1.1"
+"""
+        context_file.write_text(content)
+
+        with pytest.raises(ValueError, match="has IP but no MASK"):
+            parse_context(str(context_file))
+
+
+class TestAliasParsing:
+    """Tests for alias parsing."""
+
+    def test_single_alias(self, tmp_path: Path) -> None:
+        """Test parsing single alias."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+ETH0_ALIAS0_IP="10.0.1.2"
+ETH0_ALIAS0_MASK="255.255.255.0"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.aliases) == 1
+        alias = config.aliases[0]
+        assert alias.interface == "eth0"
+        assert str(alias.ip) == "10.0.1.2"
+        assert alias.mask == "255.255.255.0"
+
+    def test_alias_with_empty_mask(self, tmp_path: Path) -> None:
+        """Test parsing alias with empty mask (OpenNebula bug)."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+ETH0_ALIAS0_IP="10.0.1.2"
+ETH0_ALIAS0_MASK=""
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.aliases) == 1
+        alias = config.aliases[0]
+        assert alias.interface == "eth0"
+        assert str(alias.ip) == "10.0.1.2"
+        assert alias.mask is None
+
+    def test_multiple_aliases_on_same_interface(self, tmp_path: Path) -> None:
+        """Test parsing multiple aliases on same interface."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+ETH0_ALIAS0_IP="10.0.1.2"
+ETH0_ALIAS0_MASK="255.255.255.0"
+ETH0_ALIAS1_IP="10.0.1.3"
+ETH0_ALIAS1_MASK="255.255.255.0"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.aliases) == 2
+        assert config.aliases[0].interface == "eth0"
+        assert config.aliases[1].interface == "eth0"
+        assert str(config.aliases[0].ip) == "10.0.1.2"
+        assert str(config.aliases[1].ip) == "10.0.1.3"
+
+    def test_aliases_on_multiple_interfaces(self, tmp_path: Path) -> None:
+        """Test parsing aliases on different interfaces."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+ETH0_ALIAS0_IP="10.0.1.2"
+ETH0_ALIAS0_MASK="255.255.255.0"
+ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH1_ALIAS0_IP="192.168.1.2"
+ETH1_ALIAS0_MASK="255.255.255.0"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.aliases) == 2
+        assert config.aliases[0].interface == "eth0"
+        assert config.aliases[1].interface == "eth1"
+
+
+class TestOperationalVariables:
+    """Tests for operational variable parsing."""
+
+    def test_hostname(self, tmp_path: Path) -> None:
+        """Test hostname parsing."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text('HOSTNAME="router-01"\n')
+
+        config = parse_context(str(context_file))
+
+        assert config.hostname == "router-01"
+
+    def test_ssh_public_key(self, tmp_path: Path) -> None:
+        """Test SSH public key parsing."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text('SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAA..."\n')
+
+        config = parse_context(str(context_file))
+
+        assert config.ssh_public_key == "ssh-rsa AAAAB3NzaC1yc2EAAAA..."
+
+    def test_onecontext_mode_stateless(self, tmp_path: Path) -> None:
+        """Test ONECONTEXT_MODE stateless."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text('ONECONTEXT_MODE="stateless"\n')
+
+        config = parse_context(str(context_file))
+
+        assert config.onecontext_mode == OnecontextMode.STATELESS
+
+    def test_onecontext_mode_freeze(self, tmp_path: Path) -> None:
+        """Test ONECONTEXT_MODE freeze."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text('ONECONTEXT_MODE="freeze"\n')
+
+        config = parse_context(str(context_file))
+
+        assert config.onecontext_mode == OnecontextMode.FREEZE
+
+    def test_onecontext_mode_default(self, tmp_path: Path) -> None:
+        """Test default ONECONTEXT_MODE when not specified."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text("")
+
+        config = parse_context(str(context_file))
+
+        assert config.onecontext_mode == OnecontextMode.STATELESS
+
+    def test_onecontext_mode_invalid(self, tmp_path: Path) -> None:
+        """Test invalid ONECONTEXT_MODE defaults to stateless."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text('ONECONTEXT_MODE="invalid"\n')
+
+        config = parse_context(str(context_file))
+
+        assert config.onecontext_mode == OnecontextMode.STATELESS
+
+
+class TestJsonVariables:
+    """Tests for JSON variable parsing."""
+
+    def test_routes_json(self, tmp_path: Path) -> None:
+        """Test ROUTES_JSON parsing."""
+        context_file = tmp_path / "one_env"
+        routes_data = {
+            "static": [
+                {
+                    "interface": "eth1",
+                    "destination": "0.0.0.0/0",
+                    "gateway": "10.0.1.254",
+                }
+            ]
+        }
+        context_file.write_text(f'ROUTES_JSON=\'{json.dumps(routes_data)}\'\n')
+
+        config = parse_context(str(context_file))
+
+        assert config.routes is not None
+        assert len(config.routes.static) == 1
+        assert config.routes.static[0].interface == "eth1"
+        assert config.routes.static[0].destination == "0.0.0.0/0"
+
+    def test_ospf_json(self, tmp_path: Path) -> None:
+        """Test OSPF_JSON parsing."""
+        context_file = tmp_path / "one_env"
+        ospf_data = {
+            "enabled": True,
+            "router_id": "10.0.0.1",
+            "interfaces": [{"name": "eth1", "area": "0.0.0.0"}],
+            "redistribute": ["connected"],
+        }
+        context_file.write_text(f'OSPF_JSON=\'{json.dumps(ospf_data)}\'\n')
+
+        config = parse_context(str(context_file))
+
+        assert config.ospf is not None
+        assert config.ospf.enabled is True
+        assert str(config.ospf.router_id) == "10.0.0.1"
+        assert len(config.ospf.interfaces) == 1
+
+    def test_dhcp_json(self, tmp_path: Path) -> None:
+        """Test DHCP_JSON parsing."""
+        context_file = tmp_path / "one_env"
+        dhcp_data = {
+            "pools": [
+                {
+                    "interface": "eth1",
+                    "range_start": "10.1.1.100",
+                    "range_end": "10.1.1.200",
+                    "gateway": "10.1.1.1",
+                    "dns": ["10.1.1.1"],
+                }
+            ]
+        }
+        context_file.write_text(f'DHCP_JSON=\'{json.dumps(dhcp_data)}\'\n')
+
+        config = parse_context(str(context_file))
+
+        assert config.dhcp is not None
+        assert len(config.dhcp.pools) == 1
+        assert config.dhcp.pools[0].interface == "eth1"
+
+    def test_nat_json(self, tmp_path: Path) -> None:
+        """Test NAT_JSON parsing."""
+        context_file = tmp_path / "one_env"
+        nat_data = {
+            "source": [
+                {
+                    "outbound_interface": "eth0",
+                    "source_address": "10.0.0.0/8",
+                    "translation": "masquerade",
+                }
+            ]
+        }
+        # Need interface to satisfy RouterConfig validation
+        content = f"""ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+NAT_JSON='{json.dumps(nat_data)}'
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert config.nat is not None
+        assert len(config.nat.source) == 1
+        assert config.nat.source[0].outbound_interface == "eth0"
+
+    def test_firewall_json(self, tmp_path: Path) -> None:
+        """Test FIREWALL_JSON parsing."""
+        context_file = tmp_path / "one_env"
+        firewall_data = {
+            "groups": {
+                "network": {"GAME": ["10.64.0.0/10"]},
+                "address": {},
+                "port": {},
+            },
+            "zones": {
+                "WAN": {"name": "WAN", "interfaces": ["eth0"], "default_action": "drop"}
+            },
+            "policies": [],
+        }
+        context_file.write_text(f'FIREWALL_JSON=\'{json.dumps(firewall_data)}\'\n')
+
+        config = parse_context(str(context_file))
+
+        assert config.firewall is not None
+        assert "GAME" in config.firewall.groups.network
+        assert "WAN" in config.firewall.zones
+
+    def test_malformed_json(self, tmp_path: Path) -> None:
+        """Test that malformed JSON raises error."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text('ROUTES_JSON=\'{"invalid": json}\'\n')
+
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            parse_context(str(context_file))
+
+    def test_invalid_json_schema(self, tmp_path: Path) -> None:
+        """Test that JSON with invalid schema raises error."""
+        context_file = tmp_path / "one_env"
+        # Missing required fields
+        context_file.write_text('OSPF_JSON=\'{"interfaces": []}\'\n')
+
+        with pytest.raises(ValueError, match="Validation error"):
+            parse_context(str(context_file))
+
+
+class TestEscapeHatches:
+    """Tests for escape hatch variables."""
+
+    def test_start_config(self, tmp_path: Path) -> None:
+        """Test START_CONFIG parsing."""
+        context_file = tmp_path / "one_env"
+        content = """START_CONFIG="set system option performance throughput
+set system syslog global facility all level info"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert config.start_config is not None
+        assert "performance throughput" in config.start_config
+
+    def test_start_script(self, tmp_path: Path) -> None:
+        """Test START_SCRIPT parsing."""
+        context_file = tmp_path / "one_env"
+        content = """START_SCRIPT="#!/bin/bash
+echo 'Configuration complete' >> /var/log/contextualization.log"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert config.start_script is not None
+        assert "#!/bin/bash" in config.start_script
+
+
+class TestCompleteContextFile:
+    """Tests for complete context files."""
+
+    def test_minimal_config(self, tmp_path: Path) -> None:
+        """Test minimal valid configuration."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text("")
+
+        config = parse_context(str(context_file))
+
+        assert config.hostname is None
+        assert config.onecontext_mode == OnecontextMode.STATELESS
+        assert len(config.interfaces) == 0
+
+    def test_comprehensive_config(self, tmp_path: Path) -> None:
+        """Test comprehensive configuration with all features."""
+        context_file = tmp_path / "one_env"
+        content = """# Identity
+HOSTNAME="router-01"
+SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAA..."
+
+# Operational
+ONECONTEXT_MODE="stateless"
+
+# Interfaces
+ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+ETH0_VROUTER_MANAGEMENT="YES"
+
+ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH1_GATEWAY="192.168.1.254"
+
+# Aliases
+ETH1_ALIAS0_IP="192.168.1.2"
+ETH1_ALIAS0_MASK="255.255.255.0"
+
+# Routes (line broken for readability)
+ROUTES_JSON='{"static": [{"interface": "eth1", "destination": "0.0.0.0/0", \
+"gateway": "192.168.1.254"}]}'
+
+# OSPF (line broken for readability)
+OSPF_JSON='{"enabled": true, "router_id": "10.0.0.1", \
+"interfaces": [{"name": "eth1", "area": "0.0.0.0"}]}'
+
+# DHCP (line broken for readability)
+DHCP_JSON='{"pools": [{"interface": "eth1", "range_start": "192.168.1.100", \
+"range_end": "192.168.1.200", "gateway": "192.168.1.1", "dns": ["192.168.1.1"]}]}'
+
+# NAT (line broken for readability)
+NAT_JSON='{"source": [{"outbound_interface": "eth1", "source_address": "10.0.0.0/8", \
+"translation": "masquerade"}]}'
+
+# Firewall (line broken for readability)
+FIREWALL_JSON='{"groups": {"network": {}, "address": {}, "port": {}}, \
+"zones": {"WAN": {"name": "WAN", "interfaces": ["eth1"], "default_action": "drop"}}, \
+"policies": []}'
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert config.hostname == "router-01"
+        assert len(config.interfaces) == 2
+        assert len(config.aliases) == 1
+        assert config.routes is not None
+        assert config.ospf is not None
+        assert config.dhcp is not None
+        assert config.nat is not None
+        assert config.firewall is not None
+
+
+class TestErrorCases:
+    """Tests for error handling."""
+
+    def test_missing_file(self) -> None:
+        """Test that missing file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            parse_context("/nonexistent/path")
+
+    def test_nat_invalid_interface_reference(self, tmp_path: Path) -> None:
+        """Test that NAT rule with invalid interface reference fails validation."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+
+NAT_JSON='{"source": [{"outbound_interface": "eth99", "translation": "masquerade"}]}'
+"""
+        context_file.write_text(content)
+
+        with pytest.raises(ValueError, match="non-existent outbound_interface"):
+            parse_context(str(context_file))
+
+
+class TestParserAPI:
+    """Tests for parser API."""
+
+    def test_context_parser_class(self, tmp_path: Path) -> None:
+        """Test using ContextParser class directly."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text('HOSTNAME="test"\n')
+
+        parser = ContextParser(str(context_file))
+        config = parser.parse()
+
+        assert config.hostname == "test"
+
+    def test_parse_context_function(self, tmp_path: Path) -> None:
+        """Test using parse_context convenience function."""
+        context_file = tmp_path / "one_env"
+        context_file.write_text('HOSTNAME="test"\n')
+
+        config = parse_context(str(context_file))
+
+        assert config.hostname == "test"


### PR DESCRIPTION
## Summary

Implements the context parser for vyos-onecontext Phase 0.2, providing comprehensive parsing of OpenNebula context variables into validated Pydantic models.

## Changes

- **Context file parser** (`src/vyos_onecontext/parser.py`):
  - Shell variable parsing with quote handling (single, double, multiline)
  - Interface configuration parsing (ETHx_IP, ETHx_MASK, ETHx_GATEWAY, etc.)
  - NIC alias parsing (ETHx_ALIASy_IP) with OpenNebula empty mask bug workaround
  - JSON variable parsing for complex configs (ROUTES_JSON, OSPF_JSON, DHCP_JSON, NAT_JSON, FIREWALL_JSON)
  - Operational variables (HOSTNAME, SSH_PUBLIC_KEY, ONECONTEXT_MODE)
  - Escape hatches (START_CONFIG, START_SCRIPT)

- **Parser API**:
  - `ContextParser` class for explicit control
  - `parse_context()` convenience function
  - Full Pydantic validation with cross-reference checks (NAT rules reference valid interfaces, etc.)

- **Test coverage** (`tests/test_parser.py`):
  - 35 comprehensive tests covering all parsing scenarios
  - Shell variable parsing edge cases
  - Interface and alias parsing
  - JSON variable parsing and validation
  - Error handling and validation failures
  - Complete context file parsing

- **Quality assurance**:
  - All tests pass (93 total including existing model tests)
  - Linting passes (ruff)
  - Type checking passes (mypy strict mode)
  - Added .gitignore to prevent committing Python artifacts

## Test plan

- [x] Unit tests pass (35 new parser tests, 58 existing model tests)
- [x] Linting passes (ruff check)
- [x] Type checking passes (mypy strict)
- [x] Parser can read shell variables with various quote styles
- [x] Parser handles multiline variables correctly
- [x] Parser extracts interface configurations dynamically
- [x] Parser handles NIC aliases with empty mask bug
- [x] Parser validates JSON variables against Pydantic models
- [x] Parser enforces cross-reference validation (NAT rules reference valid interfaces)
- [x] Parser handles missing/malformed files gracefully

## Related Issues

Implements Phase 0.2 of the VyOS Router v3 project (vyos-onecontext repository).

Generated with [Claude Code](https://claude.com/claude-code)