### PR TITLE
Add generator framework for VyOS command generation (Phase 0.4)

### DIFF
--- a/src/vyos_onecontext/generators/__init__.py
+++ b/src/vyos_onecontext/generators/__init__.py
@@ -1,0 +1,53 @@
+"""VyOS command generators.
+
+This module provides generators that convert parsed configuration models into
+VyOS CLI commands. Each generator is responsible for a specific aspect of the
+configuration (interfaces, routing, NAT, etc.).
+"""
+
+from vyos_onecontext.generators.base import BaseGenerator
+from vyos_onecontext.generators.interface import InterfaceGenerator
+from vyos_onecontext.generators.system import HostnameGenerator, SshKeyGenerator
+from vyos_onecontext.models import RouterConfig
+
+
+def generate_config(config: RouterConfig) -> list[str]:
+    """Generate all VyOS commands from a RouterConfig.
+
+    Generates commands in the correct order for VyOS commit:
+    1. System configuration (hostname, SSH keys)
+    2. Network interfaces
+    3. ... (other generators will be added in later phases)
+
+    Args:
+        config: Complete router configuration
+
+    Returns:
+        List of VyOS 'set' commands ready for execution
+    """
+    commands: list[str] = []
+
+    # System config first
+    commands.extend(HostnameGenerator(config.hostname).generate())
+    commands.extend(SshKeyGenerator(config.ssh_public_key).generate())
+
+    # Interfaces
+    commands.extend(InterfaceGenerator(config.interfaces, config.aliases).generate())
+
+    # Future generators will be added here in later phases:
+    # - Routing (static routes, OSPF)
+    # - Services (DHCP, DNS)
+    # - NAT (source, destination, binat)
+    # - Firewall (zones, policies, rules)
+    # - Custom config (START_CONFIG)
+
+    return commands
+
+
+__all__ = [
+    "BaseGenerator",
+    "HostnameGenerator",
+    "InterfaceGenerator",
+    "SshKeyGenerator",
+    "generate_config",
+]

--- a/src/vyos_onecontext/generators/base.py
+++ b/src/vyos_onecontext/generators/base.py
@@ -1,0 +1,20 @@
+"""Base generator class for VyOS command generation."""
+
+from abc import ABC, abstractmethod
+
+
+class BaseGenerator(ABC):
+    """Base class for VyOS command generators.
+
+    All generator classes should inherit from this base class and implement
+    the generate() method to produce VyOS 'set' commands.
+    """
+
+    @abstractmethod
+    def generate(self) -> list[str]:
+        """Generate VyOS configuration commands.
+
+        Returns:
+            List of VyOS 'set' commands as strings
+        """
+        pass

--- a/src/vyos_onecontext/generators/interface.py
+++ b/src/vyos_onecontext/generators/interface.py
@@ -1,0 +1,62 @@
+"""Interface configuration generator."""
+
+from vyos_onecontext.generators.base import BaseGenerator
+from vyos_onecontext.models import AliasConfig, InterfaceConfig
+
+
+class InterfaceGenerator(BaseGenerator):
+    """Generate VyOS interface configuration commands."""
+
+    def __init__(self, interfaces: list[InterfaceConfig], aliases: list[AliasConfig]):
+        """Initialize interface generator.
+
+        Args:
+            interfaces: List of interface configurations
+            aliases: List of NIC alias configurations (secondary IPs)
+        """
+        self.interfaces = interfaces
+        self.aliases = aliases
+
+    def generate(self) -> list[str]:
+        """Generate interface configuration commands.
+
+        Generates commands for:
+        - Primary interface IP addresses
+        - Interface MTU (if specified)
+        - Alias (secondary) IP addresses
+
+        Returns:
+            List of VyOS 'set' commands for interface configuration
+        """
+        commands: list[str] = []
+
+        # Build a map of interface -> parent_mask for aliases
+        interface_masks: dict[str, str] = {iface.name: iface.mask for iface in self.interfaces}
+
+        # Configure primary interfaces
+        for iface in self.interfaces:
+            # Primary IP address in CIDR notation
+            commands.append(
+                f"set interfaces ethernet {iface.name} address '{iface.to_cidr()}'"
+            )
+
+            # MTU (if specified)
+            if iface.mtu is not None:
+                commands.append(f"set interfaces ethernet {iface.name} mtu {iface.mtu}")
+
+        # Configure alias (secondary) IP addresses
+        for alias in self.aliases:
+            # Get parent interface mask for fallback if alias mask is missing
+            parent_mask = interface_masks.get(alias.interface)
+
+            if parent_mask is None:
+                # This should have been caught by validation, but be defensive
+                continue
+
+            # Add alias IP as additional address on the same interface
+            cidr = alias.to_cidr(parent_mask)
+            commands.append(
+                f"set interfaces ethernet {alias.interface} address '{cidr}'"
+            )
+
+        return commands

--- a/src/vyos_onecontext/generators/system.py
+++ b/src/vyos_onecontext/generators/system.py
@@ -1,0 +1,71 @@
+"""System configuration generators (hostname, SSH keys)."""
+
+from vyos_onecontext.generators.base import BaseGenerator
+
+
+class HostnameGenerator(BaseGenerator):
+    """Generate VyOS hostname configuration commands."""
+
+    def __init__(self, hostname: str | None):
+        """Initialize hostname generator.
+
+        Args:
+            hostname: System hostname to configure, or None to skip
+        """
+        self.hostname = hostname
+
+    def generate(self) -> list[str]:
+        """Generate hostname configuration command.
+
+        Returns:
+            List with hostname command if hostname is set, empty list otherwise
+        """
+        if self.hostname is None:
+            return []
+
+        return [f"set system host-name '{self.hostname}'"]
+
+
+class SshKeyGenerator(BaseGenerator):
+    """Generate VyOS SSH public key configuration commands."""
+
+    def __init__(self, ssh_public_key: str | None):
+        """Initialize SSH key generator.
+
+        Args:
+            ssh_public_key: SSH public key in format "type key comment", or None to skip
+        """
+        self.ssh_public_key = ssh_public_key
+
+    def generate(self) -> list[str]:
+        """Generate SSH public key configuration commands.
+
+        Parses the SSH key format (type key comment) and generates VyOS commands
+        to configure it for the vyos user.
+
+        Returns:
+            List with SSH key commands if key is set, empty list otherwise
+        """
+        if self.ssh_public_key is None:
+            return []
+
+        # Parse SSH key format: "type key comment"
+        # Example: "ssh-rsa AAAAB3NzaC1yc2E... user@host"
+        parts = self.ssh_public_key.strip().split(None, 2)
+
+        if len(parts) < 2:
+            # Invalid key format - skip configuration
+            return []
+
+        key_type = parts[0]
+        key_data = parts[1]
+
+        # Use comment as identifier if available, otherwise use "key1"
+        key_id = parts[2] if len(parts) >= 3 else "key1"
+        # Sanitize key_id for use as VyOS identifier (replace spaces with underscores)
+        key_id = key_id.replace(" ", "_")
+
+        return [
+            f"set system login user vyos authentication public-keys {key_id} key '{key_data}'",
+            f"set system login user vyos authentication public-keys {key_id} type {key_type}",
+        ]

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,0 +1,354 @@
+"""Tests for VyOS command generators."""
+
+from ipaddress import IPv4Address
+
+from vyos_onecontext.generators import (
+    HostnameGenerator,
+    InterfaceGenerator,
+    SshKeyGenerator,
+    generate_config,
+)
+from vyos_onecontext.models import AliasConfig, InterfaceConfig, RouterConfig
+
+
+class TestHostnameGenerator:
+    """Tests for hostname configuration generator."""
+
+    def test_generate_with_hostname(self):
+        """Test hostname generation with valid hostname."""
+        gen = HostnameGenerator("router-01")
+        commands = gen.generate()
+
+        assert len(commands) == 1
+        assert commands[0] == "set system host-name 'router-01'"
+
+    def test_generate_without_hostname(self):
+        """Test hostname generation with None hostname."""
+        gen = HostnameGenerator(None)
+        commands = gen.generate()
+
+        assert len(commands) == 0
+
+
+class TestSshKeyGenerator:
+    """Tests for SSH key configuration generator."""
+
+    def test_generate_with_rsa_key(self):
+        """Test SSH key generation with RSA key."""
+        key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... user@host"
+        gen = SshKeyGenerator(key)
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert (
+            "set system login user vyos authentication public-keys "
+            "user@host key 'AAAAB3NzaC1yc2EAAAADAQABAAABAQC...'"
+        ) in commands[0]
+        assert (
+            "set system login user vyos authentication public-keys "
+            "user@host type ssh-rsa"
+        ) in commands[1]
+
+    def test_generate_with_ed25519_key(self):
+        """Test SSH key generation with ED25519 key."""
+        key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI... admin@example.com"
+        gen = SshKeyGenerator(key)
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert (
+            "set system login user vyos authentication public-keys "
+            "admin@example.com key 'AAAAC3NzaC1lZDI1NTE5AAAAI...'"
+        ) in commands[0]
+        assert (
+            "set system login user vyos authentication public-keys "
+            "admin@example.com type ssh-ed25519"
+        ) in commands[1]
+
+    def test_generate_without_comment(self):
+        """Test SSH key generation without comment (uses 'key1' as default)."""
+        key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC..."
+        gen = SshKeyGenerator(key)
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert (
+            "set system login user vyos authentication public-keys "
+            "key1 key 'AAAAB3NzaC1yc2EAAAADAQABAAABAQC...'"
+        ) in commands[0]
+        assert (
+            "set system login user vyos authentication public-keys key1 type ssh-rsa"
+        ) in commands[1]
+
+    def test_generate_with_spaces_in_comment(self):
+        """Test SSH key generation with spaces in comment (replaces with underscores)."""
+        key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... John Doe"
+        gen = SshKeyGenerator(key)
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert "John_Doe" in commands[0]
+        assert "John_Doe" in commands[1]
+
+    def test_generate_with_none(self):
+        """Test SSH key generation with None."""
+        gen = SshKeyGenerator(None)
+        commands = gen.generate()
+
+        assert len(commands) == 0
+
+    def test_generate_with_invalid_key(self):
+        """Test SSH key generation with invalid key format (too few parts)."""
+        key = "invalid-key"
+        gen = SshKeyGenerator(key)
+        commands = gen.generate()
+
+        assert len(commands) == 0
+
+
+class TestInterfaceGenerator:
+    """Tests for interface configuration generator."""
+
+    def test_generate_single_interface(self):
+        """Test interface generation with single interface."""
+        iface = InterfaceConfig(
+            name="eth0",
+            ip=IPv4Address("10.0.1.1"),
+            mask="255.255.255.0",
+        )
+        gen = InterfaceGenerator([iface], [])
+        commands = gen.generate()
+
+        assert len(commands) == 1
+        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+
+    def test_generate_multiple_interfaces(self):
+        """Test interface generation with multiple interfaces."""
+        interfaces = [
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.1.1"),
+                mask="255.255.255.0",
+            ),
+            InterfaceConfig(
+                name="eth1",
+                ip=IPv4Address("192.168.1.1"),
+                mask="255.255.255.0",
+            ),
+        ]
+        gen = InterfaceGenerator(interfaces, [])
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set interfaces ethernet eth1 address '192.168.1.1/24'" in commands
+
+    def test_generate_with_mtu(self):
+        """Test interface generation with MTU specified."""
+        iface = InterfaceConfig(
+            name="eth0",
+            ip=IPv4Address("10.0.1.1"),
+            mask="255.255.255.0",
+            mtu=9000,
+        )
+        gen = InterfaceGenerator([iface], [])
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set interfaces ethernet eth0 mtu 9000" in commands
+
+    def test_generate_with_alias(self):
+        """Test interface generation with alias (secondary IP)."""
+        iface = InterfaceConfig(
+            name="eth0",
+            ip=IPv4Address("10.0.1.1"),
+            mask="255.255.255.0",
+        )
+        alias = AliasConfig(
+            interface="eth0",
+            ip=IPv4Address("10.0.1.2"),
+            mask="255.255.255.0",
+        )
+        gen = InterfaceGenerator([iface], [alias])
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set interfaces ethernet eth0 address '10.0.1.2/24'" in commands
+
+    def test_generate_with_alias_no_mask(self):
+        """Test interface generation with alias missing mask (uses parent mask)."""
+        iface = InterfaceConfig(
+            name="eth0",
+            ip=IPv4Address("129.244.246.64"),
+            mask="255.255.255.0",
+        )
+        alias = AliasConfig(
+            interface="eth0",
+            ip=IPv4Address("129.244.246.66"),
+            mask=None,  # Missing mask (OpenNebula bug)
+        )
+        gen = InterfaceGenerator([iface], [alias])
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert "set interfaces ethernet eth0 address '129.244.246.64/24'" in commands
+        assert "set interfaces ethernet eth0 address '129.244.246.66/24'" in commands
+
+    def test_generate_with_multiple_aliases(self):
+        """Test interface generation with multiple aliases on same interface."""
+        iface = InterfaceConfig(
+            name="eth0",
+            ip=IPv4Address("10.0.1.1"),
+            mask="255.255.255.0",
+        )
+        aliases = [
+            AliasConfig(
+                interface="eth0",
+                ip=IPv4Address("10.0.1.2"),
+                mask="255.255.255.0",
+            ),
+            AliasConfig(
+                interface="eth0",
+                ip=IPv4Address("10.0.1.3"),
+                mask="255.255.255.0",
+            ),
+        ]
+        gen = InterfaceGenerator([iface], aliases)
+        commands = gen.generate()
+
+        assert len(commands) == 3
+        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set interfaces ethernet eth0 address '10.0.1.2/24'" in commands
+        assert "set interfaces ethernet eth0 address '10.0.1.3/24'" in commands
+
+    def test_generate_different_subnet_masks(self):
+        """Test interface generation with different subnet masks."""
+        interfaces = [
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.1.1"),
+                mask="255.255.255.0",  # /24
+            ),
+            InterfaceConfig(
+                name="eth1",
+                ip=IPv4Address("192.168.1.1"),
+                mask="255.255.0.0",  # /16
+            ),
+        ]
+        gen = InterfaceGenerator(interfaces, [])
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set interfaces ethernet eth1 address '192.168.1.1/16'" in commands
+
+    def test_generate_empty_config(self):
+        """Test interface generation with no interfaces."""
+        gen = InterfaceGenerator([], [])
+        commands = gen.generate()
+
+        assert len(commands) == 0
+
+
+class TestGenerateConfig:
+    """Tests for top-level generate_config function."""
+
+    def test_generate_minimal_config(self):
+        """Test config generation with minimal configuration."""
+        config = RouterConfig(
+            hostname="router-01",
+            interfaces=[
+                InterfaceConfig(
+                    name="eth0",
+                    ip=IPv4Address("10.0.1.1"),
+                    mask="255.255.255.0",
+                )
+            ],
+        )
+        commands = generate_config(config)
+
+        # Should have hostname + interface
+        assert len(commands) == 2
+        assert "set system host-name 'router-01'" in commands
+        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+
+    def test_generate_full_system_config(self):
+        """Test config generation with all system features."""
+        config = RouterConfig(
+            hostname="router-01",
+            ssh_public_key="ssh-rsa AAAAB3NzaC1yc2E... user@host",
+            interfaces=[
+                InterfaceConfig(
+                    name="eth0",
+                    ip=IPv4Address("10.0.1.1"),
+                    mask="255.255.255.0",
+                    mtu=9000,
+                ),
+                InterfaceConfig(
+                    name="eth1",
+                    ip=IPv4Address("192.168.1.1"),
+                    mask="255.255.255.0",
+                ),
+            ],
+            aliases=[
+                AliasConfig(
+                    interface="eth0",
+                    ip=IPv4Address("10.0.1.2"),
+                    mask="255.255.255.0",
+                )
+            ],
+        )
+        commands = generate_config(config)
+
+        # Should have: hostname + 2 SSH key commands
+        # + 3 interface commands (2 primary + 1 MTU) + 1 alias
+        assert len(commands) == 7
+        assert "set system host-name 'router-01'" in commands
+        assert any("public-keys" in cmd for cmd in commands)
+        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set interfaces ethernet eth0 mtu 9000" in commands
+        assert "set interfaces ethernet eth1 address '192.168.1.1/24'" in commands
+        assert "set interfaces ethernet eth0 address '10.0.1.2/24'" in commands
+
+    def test_generate_no_optional_config(self):
+        """Test config generation with no optional features."""
+        config = RouterConfig(
+            interfaces=[
+                InterfaceConfig(
+                    name="eth0",
+                    ip=IPv4Address("10.0.1.1"),
+                    mask="255.255.255.0",
+                )
+            ]
+        )
+        commands = generate_config(config)
+
+        # Should only have interface command
+        assert len(commands) == 1
+        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+
+    def test_command_order(self):
+        """Test that commands are generated in correct order (system, then interfaces)."""
+        config = RouterConfig(
+            hostname="router-01",
+            ssh_public_key="ssh-rsa AAAAB3NzaC1yc2E... user@host",
+            interfaces=[
+                InterfaceConfig(
+                    name="eth0",
+                    ip=IPv4Address("10.0.1.1"),
+                    mask="255.255.255.0",
+                )
+            ],
+        )
+        commands = generate_config(config)
+
+        # Find indices of different command types
+        hostname_idx = next(i for i, cmd in enumerate(commands) if "host-name" in cmd)
+        ssh_key_idx = next(i for i, cmd in enumerate(commands) if "public-keys" in cmd)
+        interface_idx = next(i for i, cmd in enumerate(commands) if "interfaces ethernet" in cmd)
+
+        # System commands should come before interface commands
+        assert hostname_idx < interface_idx
+        assert ssh_key_idx < interface_idx


### PR DESCRIPTION
## Summary

- Implement BaseGenerator abstract base class for all command generators
- Add HostnameGenerator for system hostname configuration
- Add SshKeyGenerator for SSH public key authentication setup
- Add InterfaceGenerator for network interfaces and NIC aliases
- Create generate_config() orchestrator function that combines all generators

## Implementation Details

The generator framework converts Pydantic models into VyOS 'set' commands following these patterns:

**Command Format:**
- All commands use VyOS 'set' syntax
- Values with spaces are single-quoted
- Netmasks are converted from dotted-decimal to CIDR prefix
- Interface names are lowercase (eth0, not ETH0)

**Generator Architecture:**
- Each generator inherits from BaseGenerator
- Generators accept model instances in constructor
- generate() method returns list of command strings
- Top-level orchestrator ensures correct command ordering

**Features Implemented:**
- System hostname configuration
- SSH public key parsing and configuration (supports multiple key types)
- Network interface primary IP addresses
- Interface MTU configuration (optional)
- NIC alias (secondary IP) support with mask fallback

## Test Coverage

Comprehensive tests added in tests/test_generators.py:

- TestHostnameGenerator: 2 tests (with/without hostname)
- TestSshKeyGenerator: 6 tests (RSA, ED25519, no comment, spaces in comment, None, invalid)
- TestInterfaceGenerator: 8 tests (single, multiple, MTU, aliases, edge cases)
- TestGenerateConfig: 4 tests (minimal, full, optional, command order)

All 20 tests pass. Edge cases covered include:
- Missing optional fields (MTU, alias mask)
- Multiple aliases on same interface
- Different subnet masks across interfaces
- Invalid SSH key format handling

## Quality Gates

All quality checks pass:
- Linting (ruff): No issues
- Type checking (mypy): Success
- Tests (pytest): 134/134 passed (includes existing model/parser tests)

## Next Steps

Future phases will add generators for:
- Static routes and OSPF (Phase 1)
- DHCP server configuration
- NAT rules (source, destination, binat)
- Zone-based firewall
- Custom configuration (START_CONFIG)

Generated with Claude Code