### PR TITLE
Implement default gateway selection and routing generator (Phase 1.1)

### DIFF
--- a/src/vyos_onecontext/generators/__init__.py
+++ b/src/vyos_onecontext/generators/__init__.py
@@ -7,6 +7,7 @@ configuration (interfaces, routing, NAT, etc.).
 
 from vyos_onecontext.generators.base import BaseGenerator
 from vyos_onecontext.generators.interface import InterfaceGenerator
+from vyos_onecontext.generators.routing import RoutingGenerator
 from vyos_onecontext.generators.system import HostnameGenerator, SshKeyGenerator
 from vyos_onecontext.models import RouterConfig
 
@@ -17,7 +18,8 @@ def generate_config(config: RouterConfig) -> list[str]:
     Generates commands in the correct order for VyOS commit:
     1. System configuration (hostname, SSH keys)
     2. Network interfaces
-    3. ... (other generators will be added in later phases)
+    3. Routing (default gateway, static routes)
+    4. ... (other generators will be added in later phases)
 
     Args:
         config: Complete router configuration
@@ -34,8 +36,10 @@ def generate_config(config: RouterConfig) -> list[str]:
     # Interfaces
     commands.extend(InterfaceGenerator(config.interfaces, config.aliases).generate())
 
+    # Routing (default gateway selection)
+    commands.extend(RoutingGenerator(config.interfaces).generate())
+
     # Future generators will be added here in later phases:
-    # - Routing (static routes, OSPF)
     # - Services (DHCP, DNS)
     # - NAT (source, destination, binat)
     # - Firewall (zones, policies, rules)
@@ -48,6 +52,7 @@ __all__ = [
     "BaseGenerator",
     "HostnameGenerator",
     "InterfaceGenerator",
+    "RoutingGenerator",
     "SshKeyGenerator",
     "generate_config",
 ]

--- a/src/vyos_onecontext/generators/routing.py
+++ b/src/vyos_onecontext/generators/routing.py
@@ -57,13 +57,14 @@ class RoutingGenerator(BaseGenerator):
             Gateway IP address as string, or None if no valid gateway found
         """
 
-        def natural_sort_key(iface: InterfaceConfig) -> int:
+        def natural_sort_key(iface: InterfaceConfig) -> float:
             """Extract numeric portion of interface name for natural sorting.
 
             Ensures eth2 sorts before eth10 (numeric order, not lexicographic).
+            Non-eth interfaces are sorted after all numbered eth interfaces.
             """
             match = re.match(r"eth(\d+)", iface.name)
-            return int(match.group(1)) if match else 0
+            return float(match.group(1)) if match else float("inf")
 
         # Sort interfaces by numeric portion of name (eth0 before eth1 before eth10)
         sorted_interfaces = sorted(self.interfaces, key=natural_sort_key)

--- a/src/vyos_onecontext/generators/routing.py
+++ b/src/vyos_onecontext/generators/routing.py
@@ -1,0 +1,77 @@
+"""Routing configuration generator (static routes, default gateway)."""
+
+from vyos_onecontext.generators.base import BaseGenerator
+from vyos_onecontext.models import InterfaceConfig
+
+
+class RoutingGenerator(BaseGenerator):
+    """Generate VyOS routing configuration commands.
+
+    Handles default gateway selection and static route generation.
+    """
+
+    def __init__(self, interfaces: list[InterfaceConfig]):
+        """Initialize routing generator.
+
+        Args:
+            interfaces: List of interface configurations
+        """
+        self.interfaces = interfaces
+
+    def generate(self) -> list[str]:
+        """Generate routing configuration commands.
+
+        Generates commands for:
+        - Default gateway (automatically selected from interfaces)
+
+        The default gateway is selected from the lowest-numbered interface
+        where:
+        - Interface has a gateway configured
+        - Gateway IP differs from interface's own IP (router is not the gateway)
+        - Interface is NOT in management VRF
+
+        Returns:
+            List of VyOS 'set' commands for routing configuration
+        """
+        commands: list[str] = []
+
+        # Select default gateway
+        default_gateway = self._select_default_gateway()
+        if default_gateway:
+            commands.append(f"set protocols static route 0.0.0.0/0 next-hop {default_gateway}")
+
+        return commands
+
+    def _select_default_gateway(self) -> str | None:
+        """Select the default gateway from available interfaces.
+
+        Selection algorithm:
+        - Find the lowest-numbered interface (by name sort order) where:
+          1. Interface has a gateway configured (ETHx_GATEWAY)
+          2. Gateway IP differs from interface's own IP (router is not the gateway)
+          3. Interface is NOT in management VRF (ETHx_VROUTER_MANAGEMENT is not YES)
+
+        Returns:
+            Gateway IP address as string, or None if no valid gateway found
+        """
+        # Sort interfaces by name to ensure consistent ordering (eth0 before eth1, etc.)
+        sorted_interfaces = sorted(self.interfaces, key=lambda iface: iface.name)
+
+        for iface in sorted_interfaces:
+            # Skip interfaces without a gateway
+            if iface.gateway is None:
+                continue
+
+            # Skip if gateway equals interface IP (router IS the gateway for that network)
+            if iface.gateway == iface.ip:
+                continue
+
+            # Skip management VRF interfaces
+            if iface.management:
+                continue
+
+            # This interface has a valid gateway
+            return str(iface.gateway)
+
+        # No valid gateway found
+        return None

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -335,6 +335,39 @@ class TestRoutingGenerator:
         # eth0 should win (lowest numbered with valid gateway)
         assert commands[0] == "set protocols static route 0.0.0.0/0 next-hop 10.0.0.254"
 
+    def test_generate_natural_sorting_double_digit_interfaces(self):
+        """Test that natural sorting correctly orders eth2 before eth10.
+
+        This verifies the natural_sort_key function handles double-digit
+        interface numbers correctly (numeric order, not lexicographic).
+        """
+        interfaces = [
+            InterfaceConfig(
+                name="eth10",
+                ip=IPv4Address("10.10.0.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("10.10.0.254"),
+            ),
+            InterfaceConfig(
+                name="eth2",
+                ip=IPv4Address("10.2.0.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("10.2.0.254"),
+            ),
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.0.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("10.0.0.254"),
+            ),
+        ]
+        gen = RoutingGenerator(interfaces)
+        commands = gen.generate()
+
+        assert len(commands) == 1
+        # eth0 should win (0 < 2 < 10 in numeric order)
+        assert commands[0] == "set protocols static route 0.0.0.0/0 next-hop 10.0.0.254"
+
     def test_generate_skips_interface_without_gateway(self):
         """Test that interfaces without gateways are skipped."""
         interfaces = [

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -5,6 +5,7 @@ from ipaddress import IPv4Address
 from vyos_onecontext.generators import (
     HostnameGenerator,
     InterfaceGenerator,
+    RoutingGenerator,
     SshKeyGenerator,
     generate_config,
 )
@@ -252,6 +253,227 @@ class TestInterfaceGenerator:
         assert len(commands) == 0
 
 
+class TestRoutingGenerator:
+    """Tests for routing configuration generator."""
+
+    def test_generate_default_gateway_simple(self):
+        """Test default gateway generation with single valid gateway."""
+        interfaces = [
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.0.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("10.0.0.254"),
+            )
+        ]
+        gen = RoutingGenerator(interfaces)
+        commands = gen.generate()
+
+        assert len(commands) == 1
+        assert commands[0] == "set protocols static route 0.0.0.0/0 next-hop 10.0.0.254"
+
+    def test_generate_gateway_equals_interface_ip_ignored(self):
+        """Test that gateway is ignored when it equals the interface's own IP.
+
+        This handles the case where the router IS the gateway for a network.
+        """
+        interfaces = [
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("192.168.1.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("192.168.1.1"),  # Gateway == interface IP
+            )
+        ]
+        gen = RoutingGenerator(interfaces)
+        commands = gen.generate()
+
+        assert len(commands) == 0  # No default route generated
+
+    def test_generate_management_vrf_interface_excluded(self):
+        """Test that management VRF interfaces are excluded from default gateway selection."""
+        interfaces = [
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.0.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("10.0.0.254"),
+                management=True,  # Management VRF
+            )
+        ]
+        gen = RoutingGenerator(interfaces)
+        commands = gen.generate()
+
+        assert len(commands) == 0  # No default route generated
+
+    def test_generate_lowest_numbered_interface_wins(self):
+        """Test that the lowest-numbered interface with valid gateway wins."""
+        interfaces = [
+            InterfaceConfig(
+                name="eth2",
+                ip=IPv4Address("172.16.0.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("172.16.0.254"),
+            ),
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.0.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("10.0.0.254"),
+            ),
+            InterfaceConfig(
+                name="eth1",
+                ip=IPv4Address("192.168.1.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("192.168.1.254"),
+            ),
+        ]
+        gen = RoutingGenerator(interfaces)
+        commands = gen.generate()
+
+        assert len(commands) == 1
+        # eth0 should win (lowest numbered with valid gateway)
+        assert commands[0] == "set protocols static route 0.0.0.0/0 next-hop 10.0.0.254"
+
+    def test_generate_skips_interface_without_gateway(self):
+        """Test that interfaces without gateways are skipped."""
+        interfaces = [
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.0.1"),
+                mask="255.255.255.0",
+                # No gateway
+            ),
+            InterfaceConfig(
+                name="eth1",
+                ip=IPv4Address("192.168.1.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("192.168.1.254"),
+            ),
+        ]
+        gen = RoutingGenerator(interfaces)
+        commands = gen.generate()
+
+        assert len(commands) == 1
+        # eth1 should win (eth0 has no gateway)
+        assert commands[0] == "set protocols static route 0.0.0.0/0 next-hop 192.168.1.254"
+
+    def test_generate_complex_scenario(self):
+        """Test complex scenario with multiple exclusion conditions.
+
+        eth0: 10.0.0.1/24, gateway 10.0.0.254 -> wins (gateway != interface IP)
+        eth1: 192.168.1.1/24, gateway 192.168.1.1 -> ignored (router IS the gateway)
+        eth2: 172.16.0.1/24, no gateway -> ignored
+        eth3: 10.1.0.1/24, gateway 10.1.0.254, management=True -> ignored (management VRF)
+        """
+        interfaces = [
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.0.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("10.0.0.254"),
+            ),
+            InterfaceConfig(
+                name="eth1",
+                ip=IPv4Address("192.168.1.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("192.168.1.1"),  # Router IS gateway
+            ),
+            InterfaceConfig(
+                name="eth2",
+                ip=IPv4Address("172.16.0.1"),
+                mask="255.255.255.0",
+                # No gateway
+            ),
+            InterfaceConfig(
+                name="eth3",
+                ip=IPv4Address("10.1.0.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("10.1.0.254"),
+                management=True,  # Management VRF
+            ),
+        ]
+        gen = RoutingGenerator(interfaces)
+        commands = gen.generate()
+
+        assert len(commands) == 1
+        assert commands[0] == "set protocols static route 0.0.0.0/0 next-hop 10.0.0.254"
+
+    def test_generate_no_valid_gateway(self):
+        """Test scenario where no interface has a valid gateway."""
+        interfaces = [
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.0.1"),
+                mask="255.255.255.0",
+                # No gateway
+            ),
+            InterfaceConfig(
+                name="eth1",
+                ip=IPv4Address("192.168.1.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("192.168.1.1"),  # Router IS gateway
+            ),
+        ]
+        gen = RoutingGenerator(interfaces)
+        commands = gen.generate()
+
+        assert len(commands) == 0
+
+    def test_generate_empty_interfaces(self):
+        """Test routing generation with no interfaces."""
+        gen = RoutingGenerator([])
+        commands = gen.generate()
+
+        assert len(commands) == 0
+
+    def test_generate_fallback_to_later_interface(self):
+        """Test that later interface is used when earlier interfaces are invalid."""
+        interfaces = [
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.0.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("10.0.0.1"),  # Gateway == interface (invalid)
+            ),
+            InterfaceConfig(
+                name="eth1",
+                ip=IPv4Address("192.168.1.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("192.168.1.254"),  # Valid gateway
+            ),
+        ]
+        gen = RoutingGenerator(interfaces)
+        commands = gen.generate()
+
+        assert len(commands) == 1
+        # eth1 should win (eth0's gateway equals its own IP)
+        assert commands[0] == "set protocols static route 0.0.0.0/0 next-hop 192.168.1.254"
+
+    def test_generate_all_interfaces_management_vrf(self):
+        """Test that no default gateway is generated when all interfaces are management VRF."""
+        interfaces = [
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.0.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("10.0.0.254"),
+                management=True,
+            ),
+            InterfaceConfig(
+                name="eth1",
+                ip=IPv4Address("192.168.1.1"),
+                mask="255.255.255.0",
+                gateway=IPv4Address("192.168.1.254"),
+                management=True,
+            ),
+        ]
+        gen = RoutingGenerator(interfaces)
+        commands = gen.generate()
+
+        assert len(commands) == 0
+
+
 class TestGenerateConfig:
     """Tests for top-level generate_config function."""
 
@@ -352,3 +574,69 @@ class TestGenerateConfig:
         # System commands should come before interface commands
         assert hostname_idx < interface_idx
         assert ssh_key_idx < interface_idx
+
+    def test_generate_config_with_default_gateway(self):
+        """Test config generation includes default gateway when interface has valid gateway."""
+        config = RouterConfig(
+            hostname="router-01",
+            interfaces=[
+                InterfaceConfig(
+                    name="eth0",
+                    ip=IPv4Address("10.0.1.1"),
+                    mask="255.255.255.0",
+                    gateway=IPv4Address("10.0.1.254"),
+                )
+            ],
+        )
+        commands = generate_config(config)
+
+        # Should have hostname + interface + default route
+        assert len(commands) == 3
+        assert "set system host-name 'router-01'" in commands
+        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set protocols static route 0.0.0.0/0 next-hop 10.0.1.254" in commands
+
+    def test_generate_config_gateway_equals_interface_ip_no_route(self):
+        """Test config generation skips default gateway when gateway equals interface IP."""
+        config = RouterConfig(
+            hostname="router-01",
+            interfaces=[
+                InterfaceConfig(
+                    name="eth0",
+                    ip=IPv4Address("10.0.1.1"),
+                    mask="255.255.255.0",
+                    gateway=IPv4Address("10.0.1.1"),  # Gateway == interface IP
+                )
+            ],
+        )
+        commands = generate_config(config)
+
+        # Should only have hostname + interface (no default route)
+        assert len(commands) == 2
+        assert "set system host-name 'router-01'" in commands
+        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert not any("0.0.0.0/0" in cmd for cmd in commands)
+
+    def test_generate_config_command_order_with_routing(self):
+        """Test that routing commands come after interface commands."""
+        config = RouterConfig(
+            hostname="router-01",
+            interfaces=[
+                InterfaceConfig(
+                    name="eth0",
+                    ip=IPv4Address("10.0.1.1"),
+                    mask="255.255.255.0",
+                    gateway=IPv4Address("10.0.1.254"),
+                )
+            ],
+        )
+        commands = generate_config(config)
+
+        # Find indices of different command types
+        hostname_idx = next(i for i, cmd in enumerate(commands) if "host-name" in cmd)
+        interface_idx = next(i for i, cmd in enumerate(commands) if "interfaces ethernet" in cmd)
+        routing_idx = next(i for i, cmd in enumerate(commands) if "protocols static" in cmd)
+
+        # System -> Interfaces -> Routing
+        assert hostname_idx < interface_idx
+        assert interface_idx < routing_idx


### PR DESCRIPTION
## Summary

- Adds new `RoutingGenerator` class to handle default gateway selection and static route generation
- Implements smart gateway selection algorithm that finds the lowest-numbered interface where:
  - Interface has a gateway configured (`ETHx_GATEWAY`)
  - Gateway IP differs from interface's own IP (router is not the gateway for that network)
  - Interface is NOT in management VRF (`ETHx_VROUTER_MANAGEMENT` is not YES)
- Generates `set protocols static route 0.0.0.0/0 next-hop <gateway>` for the winning gateway
- Integrated into `generate_config()` pipeline after interface configuration

## Test plan

- [x] Test simple default gateway generation
- [x] Test gateway == interface IP is ignored (router IS the gateway)
- [x] Test management VRF interfaces excluded from gateway selection
- [x] Test lowest-numbered interface wins with multiple valid gateways
- [x] Test interfaces without gateways are skipped
- [x] Test complex multi-interface scenarios
- [x] Test no default route when no valid gateway found
- [x] Test integration with `generate_config()` including command ordering
- [x] All 235 tests pass
- [x] Linting and type checking pass

Generated with Claude Code (Claude Opus 4.5)