### PR TITLE
Remove single quotes from VyOS set commands

### DIFF
--- a/src/vyos_onecontext/generators/interface.py
+++ b/src/vyos_onecontext/generators/interface.py
@@ -37,7 +37,7 @@ class InterfaceGenerator(BaseGenerator):
         for iface in self.interfaces:
             # Primary IP address in CIDR notation
             commands.append(
-                f"set interfaces ethernet {iface.name} address '{iface.to_cidr()}'"
+                f"set interfaces ethernet {iface.name} address {iface.to_cidr()}"
             )
 
             # MTU (if specified)
@@ -56,7 +56,7 @@ class InterfaceGenerator(BaseGenerator):
             # Add alias IP as additional address on the same interface
             cidr = alias.to_cidr(parent_mask)
             commands.append(
-                f"set interfaces ethernet {alias.interface} address '{cidr}'"
+                f"set interfaces ethernet {alias.interface} address {cidr}"
             )
 
         return commands

--- a/src/vyos_onecontext/generators/system.py
+++ b/src/vyos_onecontext/generators/system.py
@@ -23,7 +23,7 @@ class HostnameGenerator(BaseGenerator):
         if self.hostname is None:
             return []
 
-        return [f"set system host-name '{self.hostname}'"]
+        return [f"set system host-name {self.hostname}"]
 
 
 class SshKeyGenerator(BaseGenerator):
@@ -66,6 +66,6 @@ class SshKeyGenerator(BaseGenerator):
         key_id = key_id.replace(" ", "_")
 
         return [
-            f"set system login user vyos authentication public-keys {key_id} key '{key_data}'",
+            f"set system login user vyos authentication public-keys {key_id} key {key_data}",
             f"set system login user vyos authentication public-keys {key_id} type {key_type}",
         ]

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -21,7 +21,7 @@ class TestHostnameGenerator:
         commands = gen.generate()
 
         assert len(commands) == 1
-        assert commands[0] == "set system host-name 'router-01'"
+        assert commands[0] == "set system host-name router-01"
 
     def test_generate_without_hostname(self):
         """Test hostname generation with None hostname."""
@@ -43,7 +43,7 @@ class TestSshKeyGenerator:
         assert len(commands) == 2
         assert (
             "set system login user vyos authentication public-keys "
-            "user@host key 'AAAAB3NzaC1yc2EAAAADAQABAAABAQC...'"
+            "user@host key AAAAB3NzaC1yc2EAAAADAQABAAABAQC..."
         ) in commands[0]
         assert (
             "set system login user vyos authentication public-keys "
@@ -59,7 +59,7 @@ class TestSshKeyGenerator:
         assert len(commands) == 2
         assert (
             "set system login user vyos authentication public-keys "
-            "admin@example.com key 'AAAAC3NzaC1lZDI1NTE5AAAAI...'"
+            "admin@example.com key AAAAC3NzaC1lZDI1NTE5AAAAI..."
         ) in commands[0]
         assert (
             "set system login user vyos authentication public-keys "
@@ -75,7 +75,7 @@ class TestSshKeyGenerator:
         assert len(commands) == 2
         assert (
             "set system login user vyos authentication public-keys "
-            "key1 key 'AAAAB3NzaC1yc2EAAAADAQABAAABAQC...'"
+            "key1 key AAAAB3NzaC1yc2EAAAADAQABAAABAQC..."
         ) in commands[0]
         assert (
             "set system login user vyos authentication public-keys key1 type ssh-rsa"
@@ -121,7 +121,7 @@ class TestInterfaceGenerator:
         commands = gen.generate()
 
         assert len(commands) == 1
-        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands
 
     def test_generate_multiple_interfaces(self):
         """Test interface generation with multiple interfaces."""
@@ -141,8 +141,8 @@ class TestInterfaceGenerator:
         commands = gen.generate()
 
         assert len(commands) == 2
-        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
-        assert "set interfaces ethernet eth1 address '192.168.1.1/24'" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands
+        assert "set interfaces ethernet eth1 address 192.168.1.1/24" in commands
 
     def test_generate_with_mtu(self):
         """Test interface generation with MTU specified."""
@@ -156,7 +156,7 @@ class TestInterfaceGenerator:
         commands = gen.generate()
 
         assert len(commands) == 2
-        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands
         assert "set interfaces ethernet eth0 mtu 9000" in commands
 
     def test_generate_with_alias(self):
@@ -175,8 +175,8 @@ class TestInterfaceGenerator:
         commands = gen.generate()
 
         assert len(commands) == 2
-        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
-        assert "set interfaces ethernet eth0 address '10.0.1.2/24'" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.2/24" in commands
 
     def test_generate_with_alias_no_mask(self):
         """Test interface generation with alias missing mask (uses parent mask)."""
@@ -194,8 +194,8 @@ class TestInterfaceGenerator:
         commands = gen.generate()
 
         assert len(commands) == 2
-        assert "set interfaces ethernet eth0 address '129.244.246.64/24'" in commands
-        assert "set interfaces ethernet eth0 address '129.244.246.66/24'" in commands
+        assert "set interfaces ethernet eth0 address 129.244.246.64/24" in commands
+        assert "set interfaces ethernet eth0 address 129.244.246.66/24" in commands
 
     def test_generate_with_multiple_aliases(self):
         """Test interface generation with multiple aliases on same interface."""
@@ -220,9 +220,9 @@ class TestInterfaceGenerator:
         commands = gen.generate()
 
         assert len(commands) == 3
-        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
-        assert "set interfaces ethernet eth0 address '10.0.1.2/24'" in commands
-        assert "set interfaces ethernet eth0 address '10.0.1.3/24'" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.2/24" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.3/24" in commands
 
     def test_generate_different_subnet_masks(self):
         """Test interface generation with different subnet masks."""
@@ -242,8 +242,8 @@ class TestInterfaceGenerator:
         commands = gen.generate()
 
         assert len(commands) == 2
-        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
-        assert "set interfaces ethernet eth1 address '192.168.1.1/16'" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands
+        assert "set interfaces ethernet eth1 address 192.168.1.1/16" in commands
 
     def test_generate_empty_config(self):
         """Test interface generation with no interfaces."""
@@ -526,8 +526,8 @@ class TestGenerateConfig:
 
         # Should have hostname + interface
         assert len(commands) == 2
-        assert "set system host-name 'router-01'" in commands
-        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set system host-name router-01" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands
 
     def test_generate_full_system_config(self):
         """Test config generation with all system features."""
@@ -560,12 +560,12 @@ class TestGenerateConfig:
         # Should have: hostname + 2 SSH key commands
         # + 3 interface commands (2 primary + 1 MTU) + 1 alias
         assert len(commands) == 7
-        assert "set system host-name 'router-01'" in commands
+        assert "set system host-name router-01" in commands
         assert any("public-keys" in cmd for cmd in commands)
-        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands
         assert "set interfaces ethernet eth0 mtu 9000" in commands
-        assert "set interfaces ethernet eth1 address '192.168.1.1/24'" in commands
-        assert "set interfaces ethernet eth0 address '10.0.1.2/24'" in commands
+        assert "set interfaces ethernet eth1 address 192.168.1.1/24" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.2/24" in commands
 
     def test_generate_no_optional_config(self):
         """Test config generation with no optional features."""
@@ -582,7 +582,7 @@ class TestGenerateConfig:
 
         # Should only have interface command
         assert len(commands) == 1
-        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands
 
     def test_command_order(self):
         """Test that commands are generated in correct order (system, then interfaces)."""
@@ -625,8 +625,8 @@ class TestGenerateConfig:
 
         # Should have hostname + interface + default route
         assert len(commands) == 3
-        assert "set system host-name 'router-01'" in commands
-        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set system host-name router-01" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands
         assert "set protocols static route 0.0.0.0/0 next-hop 10.0.1.254" in commands
 
     def test_generate_config_gateway_equals_interface_ip_no_route(self):
@@ -646,8 +646,8 @@ class TestGenerateConfig:
 
         # Should only have hostname + interface (no default route)
         assert len(commands) == 2
-        assert "set system host-name 'router-01'" in commands
-        assert "set interfaces ethernet eth0 address '10.0.1.1/24'" in commands
+        assert "set system host-name router-01" in commands
+        assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands
         assert not any("0.0.0.0/0" in cmd for cmd in commands)
 
     def test_generate_config_command_order_with_routing(self):


### PR DESCRIPTION
## Summary

VyOS does not accept single quotes around values in set commands. This PR removes the quotes from all command generators to fix the error:

```
Cannot use the single quote (') character in a value string
```

## Changes

Fixed 4 occurrences of single quotes in f-strings:

1. `system.py` line 26 - hostname command
2. `system.py` line 69 - SSH key data command  
3. `interface.py` line 40 - interface address command
4. `interface.py` line 59 - alias address command

Also updated test expectations in `test_generators.py` to match the new unquoted format.

## Testing

- Updated all test assertions to expect unquoted values
- CI tests will validate the changes

## Example

Before:
```
set system host-name 'router-01'
set interfaces ethernet eth0 address '10.0.1.1/24'
```

After:
```
set system host-name router-01
set interfaces ethernet eth0 address 10.0.1.1/24
```

Generated with [Claude Code](https://claude.com/claude-code)