### PR TITLE
Enable SSH service when SSH key is configured

### DIFF
--- a/src/vyos_onecontext/generators/system.py
+++ b/src/vyos_onecontext/generators/system.py
@@ -66,6 +66,9 @@ class SshKeyGenerator(BaseGenerator):
         key_id = key_id.replace(" ", "_")
 
         return [
+            # Enable SSH service (required since base config is wiped)
+            "set service ssh port 22",
+            # Configure the public key for authentication
             f"set system login user vyos authentication public-keys {key_id} key {key_data}",
             f"set system login user vyos authentication public-keys {key_id} type {key_type}",
         ]

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -40,15 +40,16 @@ class TestSshKeyGenerator:
         gen = SshKeyGenerator(key)
         commands = gen.generate()
 
-        assert len(commands) == 2
+        assert len(commands) == 3
+        assert commands[0] == "set service ssh port 22"
         assert (
             "set system login user vyos authentication public-keys "
             "user@host key AAAAB3NzaC1yc2EAAAADAQABAAABAQC..."
-        ) in commands[0]
+        ) in commands[1]
         assert (
             "set system login user vyos authentication public-keys "
             "user@host type ssh-rsa"
-        ) in commands[1]
+        ) in commands[2]
 
     def test_generate_with_ed25519_key(self):
         """Test SSH key generation with ED25519 key."""
@@ -56,15 +57,16 @@ class TestSshKeyGenerator:
         gen = SshKeyGenerator(key)
         commands = gen.generate()
 
-        assert len(commands) == 2
+        assert len(commands) == 3
+        assert commands[0] == "set service ssh port 22"
         assert (
             "set system login user vyos authentication public-keys "
             "admin@example.com key AAAAC3NzaC1lZDI1NTE5AAAAI..."
-        ) in commands[0]
+        ) in commands[1]
         assert (
             "set system login user vyos authentication public-keys "
             "admin@example.com type ssh-ed25519"
-        ) in commands[1]
+        ) in commands[2]
 
     def test_generate_without_comment(self):
         """Test SSH key generation without comment (uses 'key1' as default)."""
@@ -72,14 +74,15 @@ class TestSshKeyGenerator:
         gen = SshKeyGenerator(key)
         commands = gen.generate()
 
-        assert len(commands) == 2
+        assert len(commands) == 3
+        assert commands[0] == "set service ssh port 22"
         assert (
             "set system login user vyos authentication public-keys "
             "key1 key AAAAB3NzaC1yc2EAAAADAQABAAABAQC..."
-        ) in commands[0]
+        ) in commands[1]
         assert (
             "set system login user vyos authentication public-keys key1 type ssh-rsa"
-        ) in commands[1]
+        ) in commands[2]
 
     def test_generate_with_spaces_in_comment(self):
         """Test SSH key generation with spaces in comment (replaces with underscores)."""
@@ -87,9 +90,10 @@ class TestSshKeyGenerator:
         gen = SshKeyGenerator(key)
         commands = gen.generate()
 
-        assert len(commands) == 2
-        assert "John_Doe" in commands[0]
+        assert len(commands) == 3
+        assert commands[0] == "set service ssh port 22"
         assert "John_Doe" in commands[1]
+        assert "John_Doe" in commands[2]
 
     def test_generate_with_none(self):
         """Test SSH key generation with None."""
@@ -557,9 +561,9 @@ class TestGenerateConfig:
         )
         commands = generate_config(config)
 
-        # Should have: hostname + 2 SSH key commands
+        # Should have: hostname + 3 SSH commands (service enable + 2 key commands)
         # + 3 interface commands (2 primary + 1 MTU) + 1 alias
-        assert len(commands) == 7
+        assert len(commands) == 8
         assert "set system host-name router-01" in commands
         assert any("public-keys" in cmd for cmd in commands)
         assert "set interfaces ethernet eth0 address 10.0.1.1/24" in commands


### PR DESCRIPTION
## Summary

The vrouter-infra Packer build wipes the base config (`rm -f /config/config.boot*`), so the SSH service is not enabled by default when the VM boots.

This PR fixes that by automatically enabling SSH when an SSH public key is provided in context.

## Changes

- `SshKeyGenerator` now includes `set service ssh port 22` when generating SSH key commands
- Updated tests to expect 3 commands instead of 2

## Testing

- All 236 tests pass
- Verified locally that SSH key configuration now includes service enablement

---
Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.5)