### PR TITLE
Add QEMU-based integration test runner

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -21,26 +21,26 @@ sudo apt-get install qemu-system-x86 qemu-kvm genisoimage
 
 ## Running Tests Locally
 
-### 1. Build a VyOS Image
+1. **Build a VyOS Image**
 
-You need a VyOS image with vyos-onecontext pre-installed. This is typically
-built using Packer in the `deployment` repository.
+   You need a VyOS image with vyos-onecontext pre-installed. This is typically
+   built using Packer in the `deployment` repository.
 
-### 2. Run a Single Test
+2. **Run a Single Test**
 
-```bash
-# Create a context ISO
-./tests/integration/create-test-iso.sh test-context.iso tests/integration/contexts/simple.env
+   ```bash
+   # Create a context ISO
+   ./tests/integration/create-test-iso.sh test-context.iso tests/integration/contexts/simple.env
 
-# Run the test
-./tests/integration/run-qemu-test.sh /path/to/vyos-image.qcow2 test-context.iso
-```
+   # Run the test
+   ./tests/integration/run-qemu-test.sh /path/to/vyos-image.qcow2 test-context.iso
+   ```
 
-### 3. Run All Tests
+3. **Run All Tests**
 
-```bash
-./tests/integration/run-all-tests.sh /path/to/vyos-image.qcow2
-```
+   ```bash
+   ./tests/integration/run-all-tests.sh /path/to/vyos-image.qcow2
+   ```
 
 ## Test Contexts
 
@@ -92,7 +92,7 @@ When a test fails, the script prints the full serial log. You can also:
 qemu-system-x86_64 \
   -enable-kvm \
   -m 2048 \
-  -drive file=vyos.qcow2,format=qcow2,if=virtio,snapshot=on \
+  -drive file=/path/to/vyos-image.qcow2,format=qcow2,if=virtio,snapshot=on \
   -cdrom test.iso \
   -nographic
 ```

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,115 @@
+# Integration Tests
+
+End-to-end integration tests for VyOS contextualization using QEMU.
+
+## Overview
+
+These tests boot a VyOS image in QEMU with test context and validate that
+contextualization works correctly. This catches integration issues that unit
+tests miss (like the quote bug in #40).
+
+## Requirements
+
+- **VyOS image**: A VyOS Sagitta (1.4.x) qcow2 image with vyos-onecontext installed
+- **QEMU/KVM**: For running the VM
+- **genisoimage or mkisofs**: For creating context ISOs
+
+On Ubuntu/Debian:
+```bash
+sudo apt-get install qemu-system-x86 qemu-kvm genisoimage
+```
+
+## Running Tests Locally
+
+### 1. Build a VyOS Image
+
+You need a VyOS image with vyos-onecontext pre-installed. This is typically
+built using Packer in the `deployment` repository.
+
+### 2. Run a Single Test
+
+```bash
+# Create a context ISO
+./tests/integration/create-test-iso.sh test-context.iso tests/integration/contexts/simple.env
+
+# Run the test
+./tests/integration/run-qemu-test.sh /path/to/vyos-image.qcow2 test-context.iso
+```
+
+### 3. Run All Tests
+
+```bash
+./tests/integration/run-all-tests.sh /path/to/vyos-image.qcow2
+```
+
+## Test Contexts
+
+Test context files are in `contexts/`:
+
+- **simple.env**: Basic single-interface router
+- **quotes.env**: Regression test for quote bug (#40)
+- **multi-interface.env**: Multi-interface router setup
+
+## CI Integration
+
+In CI, these tests run on self-hosted KVM runners:
+
+```yaml
+jobs:
+  integration-test:
+    runs-on: [self-hosted, kvm]
+    steps:
+      - name: Download VyOS image artifact
+        # ...
+      - name: Run integration tests
+        run: ./tests/integration/run-all-tests.sh vyos-image.qcow2
+```
+
+## How It Works
+
+1. **create-test-iso.sh**: Creates an ISO with context.sh from a test context file
+2. **run-qemu-test.sh**: Boots VyOS in QEMU with the context ISO attached
+3. The VM boots and runs the vyos-onecontext boot script (triggered via udev when the context CD is mounted)
+4. The script validates contextualization by checking serial log output
+
+## Validation
+
+The test script checks:
+
+- Contextualization script executed
+- No errors in contextualization output
+- No Python exceptions in logs
+- Successful completion message in logs
+
+## Debugging Failed Tests
+
+When a test fails, the script prints the full serial log. You can also:
+
+1. Run QEMU manually with the test ISO:
+```bash
+./tests/integration/create-test-iso.sh test.iso tests/integration/contexts/simple.env
+
+qemu-system-x86_64 \
+  -enable-kvm \
+  -m 2048 \
+  -drive file=vyos.qcow2,format=qcow2,if=virtio,snapshot=on \
+  -cdrom test.iso \
+  -nographic
+```
+
+2. Log in (vyos/vyos) and check:
+```
+show configuration
+show log
+```
+
+## Writing New Tests
+
+To add a new test scenario:
+
+1. Create a new context file in `contexts/`
+2. Run with `create-test-iso.sh` and `run-qemu-test.sh`
+3. The validation is automatic via serial log checking
+
+For custom validation, modify `run-qemu-test.sh` to check specific
+configuration elements.

--- a/tests/integration/run-all-tests.sh
+++ b/tests/integration/run-all-tests.sh
@@ -63,10 +63,10 @@ for scenario in "${TEST_SCENARIOS[@]}"; do
     # Run test
     echo ""
     if "$SCRIPT_DIR/run-qemu-test.sh" "$VYOS_IMAGE" "$ISO_PATH"; then
-        echo "[PASS] PASSED: $description"
+        echo "[PASS] $description"
         ((PASSED++)) || true
     else
-        echo "[FAIL] FAILED: $description"
+        echo "[FAIL] $description"
         ((FAILED++)) || true
     fi
 

--- a/tests/integration/run-all-tests.sh
+++ b/tests/integration/run-all-tests.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Run all QEMU integration tests
+#
+# This script runs all test scenarios with different context files.
+#
+# Usage: run-all-tests.sh <vyos-image.qcow2>
+
+set -euo pipefail
+
+VYOS_IMAGE="${1:?VyOS image path required}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Validate VyOS image exists
+if [ ! -f "$VYOS_IMAGE" ]; then
+    echo "ERROR: VyOS image not found: $VYOS_IMAGE"
+    exit 1
+fi
+
+# Test scenarios
+declare -a TEST_SCENARIOS=(
+    "simple:Simple router"
+    "quotes:Quote bug regression"
+    "multi-interface:Multi-interface router"
+)
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+TOTAL_TESTS=${#TEST_SCENARIOS[@]}
+PASSED=0
+FAILED=0
+
+echo "========================================"
+echo "  VyOS Integration Test Suite"
+echo "========================================"
+echo "Image: $VYOS_IMAGE"
+echo "Tests: $TOTAL_TESTS scenarios"
+echo ""
+
+for scenario in "${TEST_SCENARIOS[@]}"; do
+    IFS=':' read -r name description <<< "$scenario"
+
+    echo "========================================"
+    echo "Test: $description"
+    echo "========================================"
+
+    CONTEXT_FILE="$SCRIPT_DIR/contexts/${name}.env"
+    if [ ! -f "$CONTEXT_FILE" ]; then
+        echo "ERROR: Context file not found: $CONTEXT_FILE"
+        ((FAILED++)) || true
+        continue
+    fi
+
+    # Create test ISO
+    ISO_PATH="$TEMP_DIR/${name}.iso"
+    echo "Creating context ISO..."
+    if ! "$SCRIPT_DIR/create-test-iso.sh" "$ISO_PATH" "$CONTEXT_FILE"; then
+        echo "ERROR: Failed to create ISO for $name"
+        ((FAILED++)) || true
+        continue
+    fi
+
+    # Run test
+    echo ""
+    if "$SCRIPT_DIR/run-qemu-test.sh" "$VYOS_IMAGE" "$ISO_PATH"; then
+        echo "[PASS] PASSED: $description"
+        ((PASSED++)) || true
+    else
+        echo "[FAIL] FAILED: $description"
+        ((FAILED++)) || true
+    fi
+
+    echo ""
+done
+
+echo "========================================"
+echo "  Test Results"
+echo "========================================"
+echo "Total:  $TOTAL_TESTS"
+echo "Passed: $PASSED"
+echo "Failed: $FAILED"
+echo ""
+
+if [ $FAILED -eq 0 ]; then
+    echo "[PASS] All tests passed!"
+    exit 0
+else
+    echo "[FAIL] Some tests failed"
+    exit 1
+fi

--- a/tests/integration/run-all-tests.sh
+++ b/tests/integration/run-all-tests.sh
@@ -16,6 +16,13 @@ if [ ! -f "$VYOS_IMAGE" ]; then
     exit 1
 fi
 
+# Validate required scripts exist (create-test-iso.sh comes from PR #52)
+if [ ! -x "$SCRIPT_DIR/create-test-iso.sh" ]; then
+    echo "ERROR: create-test-iso.sh not found or not executable"
+    echo "       This script requires the integration test fixtures (PR #52)."
+    exit 1
+fi
+
 # Test scenarios
 declare -a TEST_SCENARIOS=(
     "simple:Simple router"

--- a/tests/integration/run-qemu-test.sh
+++ b/tests/integration/run-qemu-test.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# Run VyOS in QEMU with test context and validate configuration
+#
+# This script boots a VyOS image in QEMU with a context ISO and validates
+# that contextualization works correctly.
+#
+# Usage: run-qemu-test.sh <vyos-image.qcow2> <context.iso> [timeout]
+
+set -euo pipefail
+
+VYOS_IMAGE="${1:?VyOS image path required}"
+CONTEXT_ISO="${2:?Context ISO path required}"
+TIMEOUT="${3:-180}"  # Default 3 minutes for boot + context
+
+# Validate inputs
+if [ ! -f "$VYOS_IMAGE" ]; then
+    echo "ERROR: VyOS image not found: $VYOS_IMAGE"
+    exit 1
+fi
+
+if [ ! -f "$CONTEXT_ISO" ]; then
+    echo "ERROR: Context ISO not found: $CONTEXT_ISO"
+    exit 1
+fi
+
+# Check for KVM support
+if [ ! -e /dev/kvm ]; then
+    echo "WARNING: /dev/kvm not found. Tests will run without KVM acceleration (slow)."
+    KVM_FLAG=""
+else
+    KVM_FLAG="-enable-kvm"
+fi
+
+# Create temporary directory for test artifacts
+TEST_DIR=$(mktemp -d)
+
+SERIAL_LOG="$TEST_DIR/serial.log"
+MONITOR_SOCKET="$TEST_DIR/monitor.sock"
+# Port 10022 is used for SSH forwarding from the guest.
+# Note: Tests are run sequentially by run-all-tests.sh, so no port conflicts occur.
+# If parallel execution is ever needed, dynamic port allocation should be implemented.
+SSH_PORT=10022
+QEMU_PID=""
+
+# Function to cleanup QEMU
+cleanup_qemu() {
+    if [ -n "$QEMU_PID" ] && kill -0 "$QEMU_PID" 2>/dev/null; then
+        echo "Terminating QEMU (PID: $QEMU_PID)..."
+        kill "$QEMU_PID" 2>/dev/null || true
+        sleep 2
+        if kill -0 "$QEMU_PID" 2>/dev/null; then
+            echo "Force killing QEMU..."
+            kill -9 "$QEMU_PID" 2>/dev/null || true
+        fi
+    fi
+}
+
+# Combined cleanup function to handle both QEMU and temp directory
+cleanup_all() {
+    cleanup_qemu
+    rm -rf "$TEST_DIR"
+}
+trap cleanup_all EXIT
+
+echo "Starting VyOS VM for integration testing..."
+echo "  Image: $VYOS_IMAGE"
+echo "  Context: $CONTEXT_ISO"
+echo "  Serial log: $SERIAL_LOG"
+echo "  SSH port: $SSH_PORT"
+
+# Start QEMU in background
+qemu-system-x86_64 \
+    ${KVM_FLAG:-} \
+    -m 2048 \
+    -smp 2 \
+    -drive file="$VYOS_IMAGE",format=qcow2,if=virtio,snapshot=on \
+    -cdrom "$CONTEXT_ISO" \
+    -serial file:"$SERIAL_LOG" \
+    -monitor unix:"$MONITOR_SOCKET",server,nowait \
+    -nographic \
+    -net nic,model=virtio \
+    -net user,hostfwd=tcp::${SSH_PORT}-:22 \
+    -display none \
+    &
+
+QEMU_PID=$!
+echo "QEMU started with PID: $QEMU_PID"
+
+# Wait for boot and contextualization
+echo "Waiting for VM to boot and contextualize (timeout: ${TIMEOUT}s)..."
+START_TIME=$(date +%s)
+PROGRESS_COUNTER=0
+
+while true; do
+    ELAPSED=$(($(date +%s) - START_TIME))
+
+    # Check if we've exceeded timeout
+    if [ $ELAPSED -ge $TIMEOUT ]; then
+        echo "ERROR: Timeout waiting for contextualization"
+        echo "=== Serial log ==="
+        cat "$SERIAL_LOG" || echo "No serial log available"
+        exit 1
+    fi
+
+    # Check if QEMU is still running
+    if ! kill -0 "$QEMU_PID" 2>/dev/null; then
+        echo "ERROR: QEMU process died unexpectedly"
+        echo "=== Serial log ==="
+        cat "$SERIAL_LOG" || echo "No serial log available"
+        exit 1
+    fi
+
+    # Check serial log for contextualization completion
+    # The boot script logs via syslog with tag "vyos-onecontext"
+    # Messages include: "completed successfully", "failed with exit code"
+    if [ -f "$SERIAL_LOG" ]; then
+        if grep -q "vyos-onecontext.*completed successfully" "$SERIAL_LOG" 2>/dev/null; then
+            echo "[PASS] Contextualization completed successfully"
+            break
+        elif grep -q "vyos-onecontext.*failed" "$SERIAL_LOG" 2>/dev/null; then
+            echo "ERROR: Contextualization failed"
+            echo "=== Serial log ==="
+            cat "$SERIAL_LOG"
+            exit 1
+        fi
+    fi
+
+    # Show progress every 10 seconds (5 iterations * 2s sleep)
+    ((PROGRESS_COUNTER++)) || true
+    if [ $((PROGRESS_COUNTER % 5)) -eq 0 ]; then
+        echo "  ... still waiting (${ELAPSED}s elapsed)"
+    fi
+
+    sleep 2
+done
+
+echo ""
+echo "=== Validation ==="
+
+# Give the system a moment to settle after contextualization
+sleep 5
+
+# Validate configuration by checking serial log
+VALIDATION_FAILED=0
+
+echo "Checking for expected configuration markers in serial log..."
+
+# Check that contextualization ran
+if grep -q "vyos-onecontext" "$SERIAL_LOG"; then
+    echo "[PASS] Contextualization script executed"
+else
+    echo "[FAIL] Contextualization script did not execute"
+    VALIDATION_FAILED=1
+fi
+
+# Check for errors in contextualization
+if grep -q "vyos-onecontext.*error\|vyos-onecontext.*ERROR" "$SERIAL_LOG"; then
+    echo "[FAIL] Contextualization errors detected"
+    VALIDATION_FAILED=1
+else
+    echo "[PASS] No contextualization errors detected"
+fi
+
+# Check for Python exceptions in vyos-onecontext output
+# Matches: "Traceback (most recent", "SomeError:", "SomeException:"
+# Scope to vyos-onecontext lines to avoid false positives from other system logs
+if grep "vyos-onecontext" "$SERIAL_LOG" | grep -qE "(Traceback \(most recent|[A-Z][a-zA-Z]*Error:|[A-Z][a-zA-Z]*Exception:)"; then
+    echo "[FAIL] Python exceptions detected in vyos-onecontext output"
+    VALIDATION_FAILED=1
+else
+    echo "[PASS] No Python exceptions detected in vyos-onecontext output"
+fi
+
+echo ""
+if [ $VALIDATION_FAILED -eq 0 ]; then
+    echo "=== [PASS] All validation checks passed ==="
+    echo ""
+    echo "Test completed successfully!"
+    exit 0
+else
+    echo "=== [FAIL] Validation failed ==="
+    echo ""
+    echo "=== Full serial log ==="
+    cat "$SERIAL_LOG"
+    exit 1
+fi

--- a/tests/integration/run-qemu-test.sh
+++ b/tests/integration/run-qemu-test.sh
@@ -60,7 +60,8 @@ cleanup_all() {
     cleanup_qemu
     rm -rf "$TEST_DIR"
 }
-trap cleanup_all EXIT
+# Trap EXIT, INT (Ctrl+C), and TERM (kill) to ensure QEMU cleanup
+trap cleanup_all EXIT INT TERM
 
 echo "Starting VyOS VM for integration testing..."
 echo "  Image: $VYOS_IMAGE"

--- a/tests/integration/run-qemu-test.sh
+++ b/tests/integration/run-qemu-test.sh
@@ -47,7 +47,7 @@ cleanup_qemu() {
     if [ -n "$QEMU_PID" ] && kill -0 "$QEMU_PID" 2>/dev/null; then
         echo "Terminating QEMU (PID: $QEMU_PID)..."
         kill "$QEMU_PID" 2>/dev/null || true
-        sleep 2
+        sleep 5
         if kill -0 "$QEMU_PID" 2>/dev/null; then
             echo "Force killing QEMU..."
             kill -9 "$QEMU_PID" 2>/dev/null || true
@@ -78,8 +78,8 @@ qemu-system-x86_64 \
     -serial file:"$SERIAL_LOG" \
     -monitor unix:"$MONITOR_SOCKET",server,nowait \
     -nographic \
-    -net nic,model=virtio \
-    -net user,hostfwd=tcp::${SSH_PORT}-:22 \
+    -netdev user,id=net0,hostfwd=tcp::${SSH_PORT}-:22 \
+    -device virtio-net-pci,netdev=net0 \
     -display none \
     &
 


### PR DESCRIPTION
## Summary

Phase 2 of the integration testing split from #45. This PR contains the **QEMU-specific** scripts that require KVM to run.

> **Depends on #52** - requires fixtures and ISO creation script to be merged first.

## Changes

### Test Runner Scripts
- **run-qemu-test.sh**: Boots VyOS in QEMU with context ISO
  - Serial log validation for success/failure
  - Proper cleanup with trap handlers
  - Timeout with progress reporting
  - Exception detection scoped to vyos-onecontext output
- **run-all-tests.sh**: Runs all test scenarios
  - Sequential execution (documented port constraint)
  - Pass/fail summary reporting

### Documentation
- **tests/integration/README.md**: Comprehensive guide
  - Local testing instructions
  - CI integration guidance
  - Debugging failed tests

## Requirements

- VyOS Sagitta image with vyos-onecontext pre-installed
- QEMU with KVM support
- `genisoimage` or `mkisofs`

## Usage

```bash
# Run all integration tests
./tests/integration/run-all-tests.sh /path/to/vyos-image.qcow2

# Run single test
./tests/integration/create-test-iso.sh test.iso tests/integration/contexts/simple.env
./tests/integration/run-qemu-test.sh /path/to/vyos-image.qcow2 test.iso
```

## Related

- Depends on #52 (fixtures and ISO creation)
- Split from #45 (CI workflow will be separate PR)
- Tests for #40 quote bug regression

---
Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.5)