### PR TITLE
debug: DNS diagnostic build to compare SLIRP proxy vs direct DNS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,22 @@ jobs:
           echo "Downloaded base image:"
           ls -lh vyos-base.qcow2
 
+      # DEBUG: Run DNS diagnostic build to compare SLIRP proxy vs direct DNS
+      - name: Build diagnostic image with Packer
+        working-directory: packer
+        run: |
+          packer init .
+          # Run diagnostic build - this will output DNS comparison data
+          packer build -var "base_image=${{ github.workspace }}/vyos-base.qcow2" test-image-diagnostic.pkr.hcl || true
+          echo "=== Diagnostic build complete (may have failed - check output above) ==="
+        timeout-minutes: 10
+
+      # Still try the regular build after diagnostics
       - name: Build test image with Packer
         working-directory: packer
         run: |
           packer init .
-          packer build -var "base_image=${{ github.workspace }}/vyos-base.qcow2" .
+          packer build -var "base_image=${{ github.workspace }}/vyos-base.qcow2" test-image.pkr.hcl
         timeout-minutes: 10
 
       - name: Run integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Build diagnostic image with Packer
         working-directory: packer
         run: |
-          packer init .
+          packer init test-image-diagnostic.pkr.hcl
           # Run diagnostic build - this will output DNS comparison data
           packer build -var "base_image=${{ github.workspace }}/vyos-base.qcow2" test-image-diagnostic.pkr.hcl || true
           echo "=== Diagnostic build complete (may have failed - check output above) ==="
@@ -78,7 +78,7 @@ jobs:
       - name: Build test image with Packer
         working-directory: packer
         run: |
-          packer init .
+          packer init test-image.pkr.hcl
           packer build -var "base_image=${{ github.workspace }}/vyos-base.qcow2" test-image.pkr.hcl
         timeout-minutes: 10
 

--- a/packer/scripts/diagnose-dns.sh
+++ b/packer/scripts/diagnose-dns.sh
@@ -66,6 +66,7 @@ echo
 # Test 1: Using SLIRP DNS proxy (10.0.2.3)
 echo "=== TEST 1: SLIRP DNS Proxy (10.0.2.3) ==="
 echo "This is what deployment/vrouter-infra uses"
+echo "SLIRP proxy forwards to host's DNS (10.63.4.101), which can resolve internal hosts"
 echo "nameserver 10.0.2.3" | sudo tee /etc/resolv.conf > /dev/null
 cat /etc/resolv.conf
 echo
@@ -74,6 +75,10 @@ for host in $TEST_HOSTS; do
     time getent ahostsv4 "$host" 2>&1 || echo "FAILED to resolve $host via SLIRP proxy"
     echo
 done
+# Also test internal hostname via SLIRP proxy
+echo "--- Resolving artifacts.swccdc.com via SLIRP proxy (internal host) ---"
+time getent ahostsv4 artifacts.swccdc.com 2>&1 || echo "FAILED to resolve artifacts.swccdc.com via SLIRP proxy"
+echo
 
 # Test 2: Using Google DNS directly (8.8.8.8)
 echo "=== TEST 2: Google DNS Direct (8.8.8.8) ==="

--- a/packer/scripts/diagnose-dns.sh
+++ b/packer/scripts/diagnose-dns.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# DNS diagnostic script for QEMU SLIRP networking
+# Run this inside the nested VM to understand DNS behavior
+#
+# KEY INSIGHT: deployment builds use 10.0.2.3 (SLIRP proxy) and are more reliable.
+# vyos-onecontext uses 8.8.8.8 (direct). This script compares both approaches.
+
+set -x  # Echo all commands
+
+echo "=== DNS DIAGNOSTIC START ==="
+echo "Timestamp: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+echo
+
+echo "=== Network interfaces ==="
+ip addr show
+echo
+
+echo "=== Routing table ==="
+ip route show
+echo
+
+echo "=== ARP table ==="
+ip neigh show
+echo
+
+echo "=== resolv.conf (current) ==="
+cat /etc/resolv.conf
+echo
+
+echo "=== gai.conf (address selection) ==="
+cat /etc/gai.conf 2>/dev/null || echo "(no gai.conf)"
+echo
+
+# Note: ICMP doesn't work in SLIRP, so these will fail - that's expected
+echo "=== Testing ICMP (expected to fail in SLIRP) ==="
+ping -c 1 -W 2 10.0.2.2 2>&1 || echo "ICMP to gateway failed (expected in SLIRP)"
+ping -c 1 -W 2 8.8.8.8 2>&1 || echo "ICMP to 8.8.8.8 failed (expected in SLIRP)"
+echo
+
+echo "=== Testing TCP connectivity ==="
+echo "--- TCP to 8.8.8.8:53 ---"
+if timeout 5 bash -c 'echo > /dev/tcp/8.8.8.8/53' 2>/dev/null; then
+    echo "TCP to 8.8.8.8:53 is OPEN"
+else
+    echo "TCP to 8.8.8.8:53 FAILED or timed out"
+fi
+echo "--- TCP to 8.8.8.8:443 ---"
+if timeout 5 bash -c 'echo > /dev/tcp/8.8.8.8/443' 2>/dev/null; then
+    echo "TCP to 8.8.8.8:443 is OPEN"
+else
+    echo "TCP to 8.8.8.8:443 FAILED or timed out"
+fi
+echo
+
+# =============================================================================
+# COMPARE DNS APPROACHES: SLIRP proxy (10.0.2.3) vs Direct (8.8.8.8)
+# =============================================================================
+
+TEST_HOSTS="astral.sh github.com release-assets.githubusercontent.com google.com"
+
+echo "========================================"
+echo "=== COMPARING DNS APPROACHES ==="
+echo "========================================"
+echo
+
+# Test 1: Using SLIRP DNS proxy (10.0.2.3)
+echo "=== TEST 1: SLIRP DNS Proxy (10.0.2.3) ==="
+echo "This is what deployment/vrouter-infra uses"
+echo "nameserver 10.0.2.3" | sudo tee /etc/resolv.conf > /dev/null
+cat /etc/resolv.conf
+echo
+for host in $TEST_HOSTS; do
+    echo "--- Resolving $host via 10.0.2.3 ---"
+    time getent ahostsv4 "$host" 2>&1 || echo "FAILED to resolve $host via SLIRP proxy"
+    echo
+done
+
+# Test 2: Using Google DNS directly (8.8.8.8)
+echo "=== TEST 2: Google DNS Direct (8.8.8.8) ==="
+echo "This is what vyos-onecontext currently uses"
+echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf > /dev/null
+echo "nameserver 8.8.4.4" | sudo tee -a /etc/resolv.conf > /dev/null
+cat /etc/resolv.conf
+echo
+for host in $TEST_HOSTS; do
+    echo "--- Resolving $host via 8.8.8.8 ---"
+    time getent ahostsv4 "$host" 2>&1 || echo "FAILED to resolve $host via Google DNS"
+    echo
+done
+
+# Test 3: Using Cloudflare DNS directly (1.1.1.1)
+echo "=== TEST 3: Cloudflare DNS Direct (1.1.1.1) ==="
+echo "Alternative external DNS"
+echo "nameserver 1.1.1.1" | sudo tee /etc/resolv.conf > /dev/null
+echo "nameserver 1.0.0.1" | sudo tee -a /etc/resolv.conf > /dev/null
+cat /etc/resolv.conf
+echo
+for host in $TEST_HOSTS; do
+    echo "--- Resolving $host via 1.1.1.1 ---"
+    time getent ahostsv4 "$host" 2>&1 || echo "FAILED to resolve $host via Cloudflare DNS"
+    echo
+done
+
+echo "========================================"
+echo "=== END DNS COMPARISON ==="
+echo "========================================"
+echo
+
+# Additional tests if dig is available
+if command -v dig &>/dev/null; then
+    echo "=== Additional dig tests (UDP vs TCP) ==="
+    echo "--- UDP to 8.8.8.8 ---"
+    dig +short +time=5 +tries=1 @8.8.8.8 astral.sh A || echo "dig UDP failed"
+    echo "--- TCP to 8.8.8.8 ---"
+    dig +short +time=5 +tries=1 +tcp @8.8.8.8 astral.sh A || echo "dig TCP failed"
+    echo "--- UDP to SLIRP proxy ---"
+    dig +short +time=5 +tries=1 @10.0.2.3 astral.sh A || echo "dig SLIRP failed"
+    echo
+fi
+
+echo "=== Testing HTTPS connectivity (bypasses DNS) ==="
+echo "--- curl to IP directly (no DNS needed) ---"
+curl -4 -s --connect-timeout 10 --max-time 15 -o /dev/null -w "HTTP %{http_code} to 8.8.8.8:443\n" https://8.8.8.8/ 2>&1 || echo "curl to 8.8.8.8 failed"
+echo
+
+echo "=== DNS DIAGNOSTIC END ==="

--- a/packer/test-image-diagnostic.pkr.hcl
+++ b/packer/test-image-diagnostic.pkr.hcl
@@ -1,0 +1,125 @@
+# VyOS Test Image - DNS Diagnostic Version
+#
+# This is a diagnostic version of test-image.pkr.hcl that runs extensive
+# network/DNS diagnostics before attempting any downloads.
+#
+# Usage:
+#   packer init .
+#   packer build -var "base_image=vyos-sagitta-base.qcow2" test-image-diagnostic.pkr.hcl
+
+packer {
+  required_plugins {
+    qemu = {
+      version = "~> 1.1"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
+variable "base_image" {
+  type        = string
+  description = "Path to VyOS Sagitta base image"
+}
+
+variable "vyos_password" {
+  type        = string
+  default     = "vyos"
+  description = "Password for vyos user (must match base image)"
+  sensitive   = true
+}
+
+variable "headless" {
+  type        = bool
+  default     = true
+  description = "Run build without display"
+}
+
+source "qemu" "diagnostic" {
+  vm_name          = "vyos-diagnostic.qcow2"
+  output_directory = "output-diagnostic"
+  format           = "qcow2"
+  accelerator      = "kvm"
+  headless         = var.headless
+
+  iso_url      = var.base_image
+  iso_checksum = "none"
+  disk_image   = true
+  disk_size    = 4096
+
+  memory = 2048
+  cpus   = 2
+
+  boot_wait = "45s"
+
+  communicator = "ssh"
+  ssh_username = "vyos"
+  ssh_password = var.vyos_password
+  ssh_timeout  = "5m"
+
+  shutdown_command = "sudo poweroff"
+}
+
+build {
+  sources = ["source.qemu.diagnostic"]
+
+  # Step 1: Capture initial network state (before any DNS config changes)
+  provisioner "shell" {
+    inline = [
+      "echo '=== INITIAL STATE (before any changes) ==='",
+      "echo '--- /etc/resolv.conf ---'",
+      "cat /etc/resolv.conf",
+      "echo '--- Network interfaces ---'",
+      "ip addr show",
+      "echo '--- Routes ---'",
+      "ip route show",
+      "echo '--- Initial DNS test with default config ---'",
+      "getent ahostsv4 google.com || echo 'Initial DNS test failed'",
+    ]
+  }
+
+  # Step 2: Configure DNS to use Google DNS (same as production)
+  provisioner "shell" {
+    inline = [
+      "echo 'nameserver 8.8.8.8' | sudo tee /etc/resolv.conf",
+      "echo 'nameserver 8.8.4.4' | sudo tee -a /etc/resolv.conf",
+      "echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf",
+      "echo '--- Updated resolv.conf ---'",
+      "cat /etc/resolv.conf",
+    ]
+  }
+
+  # Step 3: Run comprehensive DNS diagnostics
+  provisioner "file" {
+    source      = "scripts/diagnose-dns.sh"
+    destination = "/tmp/diagnose-dns.sh"
+  }
+
+  provisioner "shell" {
+    inline = [
+      "chmod +x /tmp/diagnose-dns.sh",
+      "/tmp/diagnose-dns.sh 2>&1",
+    ]
+  }
+
+  # Step 4: Attempt the actual download (this is what fails in CI)
+  provisioner "shell" {
+    inline = [
+      "echo '=== ATTEMPTING ACTUAL DOWNLOAD ==='",
+      "echo '--- Checking DNS one more time ---'",
+      "getent ahostsv4 astral.sh || echo 'DNS check failed'",
+      "echo '--- Attempting curl to astral.sh ---'",
+      "curl -4 -v --connect-timeout 30 --max-time 60 -LsSf https://astral.sh/uv/install.sh -o /tmp/uv-install.sh || echo 'curl failed with exit code $?'",
+      "echo '--- Download result ---'",
+      "ls -la /tmp/uv-install.sh 2>/dev/null || echo 'File not downloaded'",
+      "head -20 /tmp/uv-install.sh 2>/dev/null || echo 'Cannot read file'",
+    ]
+  }
+
+  # Step 5: Even if download fails, capture final state
+  provisioner "shell" {
+    inline = [
+      "echo '=== FINAL STATE ==='",
+      "echo 'Diagnostic build complete. Check output above for DNS issues.'",
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Diagnostic PR to investigate intermittent DNS resolution failures in CI Packer builds.

**What this does:**
- Adds a diagnostic Packer build that runs BEFORE the regular build
- Compares three DNS approaches:
  - `10.0.2.3` (SLIRP DNS proxy) - what deployment/vrouter-infra uses
  - `8.8.8.8` (Google DNS direct) - what vyos-onecontext currently uses  
  - `1.1.1.1` (Cloudflare DNS direct) - alternative

- Tests resolution of: `astral.sh`, `github.com`, `release-assets.githubusercontent.com`, `google.com`

**Background:**
We've seen DNS failures where:
- Some hosts resolve (e.g., `astral.sh`) but others don't (e.g., `release-assets.githubusercontent.com`)
- Failures are consistent within a run (not intermittent)
- deployment repo found 10.0.2.3 more reliable than 8.8.8.8

**Expected output:**
The diagnostic build will show which DNS approach works in CI, helping us decide whether to switch vyos-onecontext to use SLIRP proxy like deployment does.

---

Generated with Claude Code (Opus 4.5)