### PR TITLE
fix(packer): integrate with vyos-hostsd for DNS configuration

### DIFF
--- a/packer/test-image.pkr.hcl
+++ b/packer/test-image.pkr.hcl
@@ -116,26 +116,26 @@ build {
   }
 
   # Configure DNS for build-time network access
-  # Use Google DNS for more reliable IPv4 resolution (QEMU SLIRP supports forwarding)
+  # VyOS has vyos-hostsd which manages /etc/resolv.conf. Writing to resolv.conf
+  # directly causes race conditions as vyos-hostsd will overwrite it. Instead,
+  # we add DNS servers through vyos-hostsd-client with the "system" tag, which
+  # ensures they're included in resolv.conf and persist across any regeneration.
+  # We use QEMU SLIRP's DNS proxy (10.0.2.3) which forwards to the host resolver.
   provisioner "shell" {
     inline = [
-      "echo 'nameserver 8.8.8.8' | sudo tee /etc/resolv.conf",
-      "echo 'nameserver 8.8.4.4' | sudo tee -a /etc/resolv.conf",
-      "sleep 2"
+      # Add DNS server through vyos-hostsd with system tag (survives regeneration)
+      "sudo /usr/bin/vyos-hostsd-client --add-name-servers 10.0.2.3 --tag system --apply",
+      # Prefer IPv4 over IPv6 (QEMU SLIRP doesn't support IPv6)
+      "echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf",
+      # Verify DNS is working before proceeding
+      "for i in $(seq 1 10); do getent ahostsv4 astral.sh && break; echo \"DNS attempt $i failed, retrying...\"; sleep 5; done",
+      "getent ahostsv4 astral.sh > /dev/null || { echo 'ERROR: DNS resolution failed'; exit 1; }"
     ]
   }
 
   # Create venv and install the package using uv
   provisioner "shell" {
     inline = [
-      # Use Google DNS for more reliable IPv4 resolution
-      # QEMU SLIRP's DNS (10.0.2.3) sometimes only returns IPv6 addresses
-      "echo 'nameserver 8.8.8.8' | sudo tee /etc/resolv.conf",
-      "echo 'nameserver 8.8.4.4' | sudo tee -a /etc/resolv.conf",
-      # Prefer IPv4 over IPv6 (QEMU SLIRP doesn't support IPv6)
-      "echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf",
-      # Wait for DNS to be ready - check for IPv4 address specifically
-      "for i in $(seq 1 10); do getent ahostsv4 astral.sh && break; echo \"DNS attempt $i failed, retrying...\"; sleep 5; done",
       # Install uv with retry (force IPv4 - QEMU SLIRP doesn't support IPv6)
       "curl -4 --retry 5 --retry-delay 5 --retry-connrefused -LsSf https://astral.sh/uv/install.sh | sudo UV_INSTALLER_DOWNLOAD_TIMEOUT=120 sh",
       # Create virtual environment and install package


### PR DESCRIPTION
## Summary

Fixes intermittent DNS resolution failures during Packer builds by integrating with VyOS's DNS management system rather than fighting it.

## Root Cause

VyOS has `vyos-hostsd`, a DNS configuration service that manages `/etc/resolv.conf` using a **tag-based system**:

- DNS servers are registered with tags like `system`, `dhcp-eth0`, etc.
- Only tags listed in `name_server_tags_system` are written to `/etc/resolv.conf`
- By default, only the `system` tag is in this list

**The Problem:**

QEMU SLIRP provides DNS via DHCP at `10.0.2.3`, which VyOS registers with tag `dhcp-eth0`. Since `dhcp-eth0` is not in `name_server_tags_system`, this DNS **never reaches** `/etc/resolv.conf` - the file remains empty.

When our Packer provisioner wrote DNS servers directly to `/etc/resolv.conf`, any `vyos-hostsd` event (DHCP renewal, config changes) would regenerate the file from its internal state - overwriting our changes with an empty file.

### The Race Condition Pattern

```
1. Packer writes "nameserver 8.8.8.8" to /etc/resolv.conf
2. getent astral.sh succeeds (reads our DNS)
3. DHCP event triggers vyos-hostsd to regenerate resolv.conf
4. vyos-hostsd writes resolv.conf from state (empty for system tag)
5. curl github.com fails (resolv.conf now empty)
```

This explains the CI failure pattern where DNS would work briefly then fail:
```
==> qemu.test: 104.26.12.77    STREAM astral.sh   <-- getent succeeded
==> qemu.test: curl: (6) Could not resolve host: astral.sh   <-- curl failed
```

## The Fix

Instead of writing to `/etc/resolv.conf` directly (or stopping `vyos-hostsd`), we integrate with VyOS's DNS management:

```bash
sudo /usr/bin/vyos-hostsd-client --add-name-servers 10.0.2.3 --tag system --apply
```

This:
1. Registers DNS in vyos-hostsd's state under the `system` tag
2. Since `system` is in `name_server_tags_system`, it gets written to resolv.conf
3. Any future regeneration still includes our DNS
4. DHCP operations (which use `dhcp-eth0` tag) don't affect our entry

### Why This Is Better Than Stopping vyos-hostsd

- Works **with** VyOS's mechanisms rather than disabling them
- DNS persists across any resolv.conf regeneration events
- No services are stopped or disabled
- Same pattern could work in the final deployed image if needed

## Testing

- Verified root cause by examining vyos-hostsd state and tags on a live VM
- Reproduced the race condition by manually writing resolv.conf then triggering vyos-hostsd
- Stress tested with 20 rapid vyos-hostsd events - DNS remained stable
- 3/3 sequential Packer builds completed successfully on runner 10.63.0.210

---

Generated with [Claude Code](https://claude.ai/code) (Claude Opus 4.5)