### PR TITLE
Phase 6: Firewall Generator Implementation

### DIFF
--- a/src/vyos_onecontext/generators/__init__.py
+++ b/src/vyos_onecontext/generators/__init__.py
@@ -7,6 +7,7 @@ configuration (interfaces, routing, NAT, etc.).
 
 from vyos_onecontext.generators.base import BaseGenerator
 from vyos_onecontext.generators.dhcp import DhcpGenerator
+from vyos_onecontext.generators.firewall import FirewallGenerator
 from vyos_onecontext.generators.interface import InterfaceGenerator
 from vyos_onecontext.generators.nat import NatGenerator
 from vyos_onecontext.generators.ospf import OspfGenerator
@@ -63,9 +64,11 @@ def generate_config(config: RouterConfig) -> list[str]:
     # NAT (source, destination, binat)
     commands.extend(NatGenerator(config.nat).generate())
 
+    # Firewall (groups, zones, global state policy, inter-zone policies)
+    commands.extend(FirewallGenerator(config.firewall).generate())
+
     # Future generators will be added here in later phases:
     # - DNS service (recursive resolver, forwarding)
-    # - Firewall (zones, policies, rules)
     # - Custom config (START_CONFIG)
 
     return commands
@@ -74,6 +77,7 @@ def generate_config(config: RouterConfig) -> list[str]:
 __all__ = [
     "BaseGenerator",
     "DhcpGenerator",
+    "FirewallGenerator",
     "HostnameGenerator",
     "InterfaceGenerator",
     "NatGenerator",

--- a/src/vyos_onecontext/generators/firewall.py
+++ b/src/vyos_onecontext/generators/firewall.py
@@ -1,0 +1,276 @@
+"""Firewall configuration generator.
+
+This module generates VyOS zone-based firewall configuration commands including:
+- Firewall groups (network, address, port groups)
+- Firewall zones with interface assignments
+- Global state policies (established/related/invalid)
+- Inter-zone policies with filtering rules
+"""
+
+from vyos_onecontext.generators.base import BaseGenerator
+from vyos_onecontext.models import FirewallConfig
+
+
+class FirewallGenerator(BaseGenerator):
+    """Generate VyOS zone-based firewall configuration commands.
+
+    Handles four main aspects of firewall configuration:
+    1. Groups - Reusable sets of networks, addresses, or ports
+    2. Zones - Security zones with interface membership
+    3. Global state policies - Automatic handling of established/related/invalid traffic
+    4. Zone policies - Filtering rules between zone pairs
+
+    Rule numbering:
+    - Zone policy rules: 100, 200, 300...
+    - Increment is 100 to allow manual rule insertion if needed
+    """
+
+    def __init__(self, firewall: FirewallConfig | None):
+        """Initialize firewall generator.
+
+        Args:
+            firewall: Firewall configuration (None if firewall is not configured)
+        """
+        self.firewall = firewall
+
+    def generate(self) -> list[str]:
+        """Generate all firewall configuration commands.
+
+        Returns:
+            List of VyOS 'set' commands for firewall configuration
+        """
+        commands: list[str] = []
+
+        # If firewall is not configured, return empty list
+        if self.firewall is None:
+            return commands
+
+        # Generate global state policies (must come first)
+        commands.extend(self._generate_global_state_policy())
+
+        # Generate firewall groups
+        commands.extend(self._generate_groups())
+
+        # Generate firewall zones
+        commands.extend(self._generate_zones())
+
+        # Generate inter-zone policies
+        commands.extend(self._generate_policies())
+
+        return commands
+
+    def _generate_global_state_policy(self) -> list[str]:
+        """Generate global state-based firewall policies.
+
+        These policies automatically handle connection state across all traffic:
+        - established: Accept packets from established connections
+        - related: Accept packets related to established connections (e.g., FTP data)
+        - invalid: Drop malformed or suspicious packets
+
+        This is a security best practice that applies globally before zone rules.
+
+        Returns:
+            List of VyOS 'set' commands for global state policies
+        """
+        commands: list[str] = []
+
+        commands.append("set firewall global-options state-policy established action accept")
+        commands.append("set firewall global-options state-policy related action accept")
+        commands.append("set firewall global-options state-policy invalid action drop")
+
+        return commands
+
+    def _generate_groups(self) -> list[str]:
+        """Generate firewall group definitions.
+
+        Firewall groups allow defining named sets of networks, addresses, or ports
+        that can be referenced in firewall rules. This promotes reusability and
+        cleaner rule definitions.
+
+        Types:
+        - network-group: CIDR network ranges (e.g., 10.0.0.0/8)
+        - address-group: Individual IP addresses (e.g., 10.1.1.1)
+        - port-group: Port numbers (e.g., 80, 443)
+
+        Returns:
+            List of VyOS 'set' commands for firewall groups
+        """
+        commands: list[str] = []
+
+        # Type narrowing: we know self.firewall is not None because generate() checks
+        if self.firewall is None:
+            return commands
+
+        # Network groups (CIDR notation)
+        for group_name, networks in self.firewall.groups.network.items():
+            for network in networks:
+                commands.append(
+                    f"set firewall group network-group {group_name} network '{network}'"
+                )
+
+        # Address groups (individual IPs)
+        for group_name, addresses in self.firewall.groups.address.items():
+            for address in addresses:
+                commands.append(
+                    f"set firewall group address-group {group_name} address '{address}'"
+                )
+
+        # Port groups
+        for group_name, ports in self.firewall.groups.port.items():
+            for port in ports:
+                commands.append(f"set firewall group port-group {group_name} port {port}")
+
+        return commands
+
+    def _generate_zones(self) -> list[str]:
+        """Generate firewall zone definitions.
+
+        Zones group interfaces by security level and define default actions.
+        Each zone has:
+        - Name (e.g., WAN, GAME, SCORING)
+        - Interface membership
+        - Default action (drop or reject) when no policy rules match
+
+        Security note: default_action cannot be 'accept' (enforced by model).
+
+        Returns:
+            List of VyOS 'set' commands for firewall zones
+        """
+        commands: list[str] = []
+
+        # Type narrowing: we know self.firewall is not None because generate() checks
+        if self.firewall is None:
+            return commands
+
+        for zone_name, zone in self.firewall.zones.items():
+            # Add interfaces to zone
+            for interface in zone.interfaces:
+                commands.append(f"set firewall zone {zone_name} interface {interface}")
+
+            # Set default action for zone
+            commands.append(f"set firewall zone {zone_name} default-action {zone.default_action}")
+
+        return commands
+
+    def _generate_policies(self) -> list[str]:
+        """Generate inter-zone firewall policies.
+
+        Policies define filtering rules for traffic flowing from one zone to another.
+        Each policy consists of:
+        - Source zone (from)
+        - Destination zone (to)
+        - Named ruleset (e.g., "GAME-to-SCORING")
+        - Ordered list of rules with actions
+
+        Rule numbering starts at 100, increments by 100.
+
+        Returns:
+            List of VyOS 'set' commands for inter-zone policies
+        """
+        commands: list[str] = []
+
+        # Type narrowing: we know self.firewall is not None because generate() checks
+        if self.firewall is None:
+            return commands
+
+        for policy in self.firewall.policies:
+            # Create ruleset name (e.g., "GAME-to-SCORING")
+            ruleset_name = f"{policy.from_zone}-to-{policy.to_zone}"
+
+            # Set default action for this ruleset (typically drop)
+            # Note: We use 'drop' as the default since zone default_action can only be drop/reject
+            commands.append(f"set firewall ipv4 name {ruleset_name} default-action drop")
+
+            # Generate rules for this policy
+            for idx, rule in enumerate(policy.rules, start=1):
+                rule_num = idx * 100
+
+                # Action (accept, drop, reject)
+                commands.append(
+                    f"set firewall ipv4 name {ruleset_name} rule {rule_num} action {rule.action}"
+                )
+
+                # Protocol (tcp, udp, icmp, tcp_udp)
+                if rule.protocol:
+                    # Handle tcp_udp specially - VyOS uses 'tcp_udp' syntax
+                    commands.append(
+                        f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                        f"protocol {rule.protocol}"
+                    )
+
+                # Source filters (address, address-group, or network-group)
+                if rule.source_address:
+                    commands.append(
+                        f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                        f"source address {rule.source_address}"
+                    )
+                if rule.source_address_group:
+                    commands.append(
+                        f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                        f"source group address-group {rule.source_address_group}"
+                    )
+                if rule.source_network_group:
+                    commands.append(
+                        f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                        f"source group network-group {rule.source_network_group}"
+                    )
+
+                # Destination filters (address, address-group, or network-group)
+                if rule.destination_address:
+                    commands.append(
+                        f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                        f"destination address {rule.destination_address}"
+                    )
+                if rule.destination_address_group:
+                    commands.append(
+                        f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                        f"destination group address-group {rule.destination_address_group}"
+                    )
+                if rule.destination_network_group:
+                    commands.append(
+                        f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                        f"destination group network-group {rule.destination_network_group}"
+                    )
+
+                # Destination port filters (inline or port-group)
+                if rule.destination_port is not None:
+                    # Handle both single port and list of ports
+                    if isinstance(rule.destination_port, list):
+                        # For multiple ports, generate separate commands for each
+                        for port in rule.destination_port:
+                            commands.append(
+                                f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                                f"destination port {port}"
+                            )
+                    else:
+                        commands.append(
+                            f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                            f"destination port {rule.destination_port}"
+                        )
+                if rule.destination_port_group:
+                    commands.append(
+                        f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                        f"destination group port-group {rule.destination_port_group}"
+                    )
+
+                # ICMP type filter (only valid when protocol is icmp)
+                if rule.icmp_type:
+                    commands.append(
+                        f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                        f"icmp type-name {rule.icmp_type}"
+                    )
+
+                # Description
+                if rule.description:
+                    commands.append(
+                        f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                        f"description '{rule.description}'"
+                    )
+
+            # Bind ruleset to zone pair
+            commands.append(
+                f"set firewall zone {policy.from_zone} from {policy.to_zone} "
+                f"firewall name {ruleset_name}"
+            )
+
+        return commands


### PR DESCRIPTION
## Summary

Implements Phase 6 of the vyos-onecontext implementation plan: zone-based firewall configuration.

## Changes

### New Files
- `src/vyos_onecontext/generators/firewall.py` - Complete firewall generator implementation

### Modified Files
- `src/vyos_onecontext/generators/__init__.py` - Register FirewallGenerator and integrate into command generation
- `tests/test_generators.py` - Add 25 comprehensive unit tests for firewall functionality

## Implementation Details

### Firewall Generator Components

1. **Global State Policies** (`_generate_global_state_policy`)
   - Automatic handling of established/related/invalid traffic
   - Applied globally before zone-specific rules
   - Security best practice for stateful firewalling

2. **Firewall Groups** (`_generate_groups`)
   - `network-group`: CIDR network ranges (e.g., 10.0.0.0/8)
   - `address-group`: Individual IP addresses (e.g., 10.1.1.1)
   - `port-group`: Port numbers (e.g., 80, 443)
   - Promotes reusability and cleaner rule definitions

3. **Zone Definitions** (`_generate_zones`)
   - Interface-to-zone assignments
   - Default actions (drop/reject) when no rules match
   - Security note: default_action cannot be 'accept' (enforced by Pydantic model)

4. **Inter-Zone Policies** (`_generate_policies`)
   - Ruleset naming convention: "FROM-to-TO" (e.g., "WAN-to-GAME")
   - Rule numbering: 100, 200, 300... (100 increment for manual insertion)
   - Support for protocol filters: tcp, udp, icmp, tcp_udp
   - Support for address/network/port groups and inline values
   - ICMP type filtering with symbolic names (e.g., echo-request)
   - Zone bindings created for each policy

### VyOS Sagitta Syntax

The generator uses modern VyOS Sagitta (1.4.x) syntax:
```
# Global state policies
set firewall global-options state-policy established action accept

# Groups
set firewall group network-group GAME network '10.64.0.0/10'
set firewall group address-group SCORING_ENGINE address '10.63.0.101'
set firewall group port-group WEB port 80

# Zones
set firewall zone WAN interface eth0
set firewall zone WAN default-action drop

# Policies
set firewall ipv4 name WAN-to-GAME default-action drop
set firewall ipv4 name WAN-to-GAME rule 100 action accept
set firewall ipv4 name WAN-to-GAME rule 100 protocol icmp
set firewall ipv4 name WAN-to-GAME rule 100 icmp type-name echo-request
set firewall zone WAN from GAME firewall name WAN-to-GAME
```

## Test Coverage

Added 25 new test cases covering:
- Empty/None configuration handling
- Global state policy generation
- All group types (network, address, port)
- Zone definitions with single/multiple interfaces
- Simple and complex policy rules
- Rule numbering across multiple rules
- Group references in rules
- Inline addresses and ports
- Protocol filters (tcp, udp, icmp, tcp_udp)
- ICMP type filtering
- Multiple policies between different zone pairs
- Complete end-to-end firewall configuration

## Quality Checks

- All 405 tests passing
- Ruff linting: passed
- MyPy type checking: passed
- Follows existing generator patterns (NAT, DHCP, OSPF)
- All code formatted with ruff

## Documentation References

- Implementation plan: `docs/projects/active/vyos-router-v3/implementation-plan.md` (Phase 6)
- Context reference: `docs/context-reference.md` (FIREWALL_JSON section)
- Design document: `docs/design.md`

## Integration

The FirewallGenerator is registered in the command generation pipeline after NAT, following the natural packet flow order (NAT happens before firewall evaluation).

## Test Plan

- [x] Unit tests for all generator methods
- [x] Integration tests with existing smoke tests
- [x] Validation of VyOS command syntax
- [x] Referential integrity checks (policies reference existing zones/groups)
- [x] Edge cases (empty config, None values, etc.)

Generated with Claude Code (Sonnet 4.5)