### PR TITLE
feat(models): Add RFC 1123 hostname validation

### DIFF
--- a/src/vyos_onecontext/generators/interface.py
+++ b/src/vyos_onecontext/generators/interface.py
@@ -36,9 +36,7 @@ class InterfaceGenerator(BaseGenerator):
         # Configure primary interfaces
         for iface in self.interfaces:
             # Primary IP address in CIDR notation
-            commands.append(
-                f"set interfaces ethernet {iface.name} address {iface.to_cidr()}"
-            )
+            commands.append(f"set interfaces ethernet {iface.name} address {iface.to_cidr()}")
 
             # MTU (if specified)
             if iface.mtu is not None:
@@ -55,8 +53,6 @@ class InterfaceGenerator(BaseGenerator):
 
             # Add alias IP as additional address on the same interface
             cidr = alias.to_cidr(parent_mask)
-            commands.append(
-                f"set interfaces ethernet {alias.interface} address {cidr}"
-            )
+            commands.append(f"set interfaces ethernet {alias.interface} address {cidr}")
 
         return commands

--- a/src/vyos_onecontext/generators/vrf.py
+++ b/src/vyos_onecontext/generators/vrf.py
@@ -54,8 +54,7 @@ class VrfGenerator(BaseGenerator):
         vrf_gateway = self._select_vrf_default_gateway(management_interfaces)
         if vrf_gateway:
             commands.append(
-                f"set vrf name {VRF_NAME} protocols static route 0.0.0.0/0 "
-                f"next-hop {vrf_gateway}"
+                f"set vrf name {VRF_NAME} protocols static route 0.0.0.0/0 next-hop {vrf_gateway}"
             )
 
         return commands

--- a/src/vyos_onecontext/models/config.py
+++ b/src/vyos_onecontext/models/config.py
@@ -59,20 +59,16 @@ class RouterConfig(BaseModel):
         if v is None:
             return None
 
-        if len(v) > 253:
-            raise ValueError("Hostname too long (max 253 chars)")
-
-        # RFC 1123 hostname pattern:
-        # - Labels separated by dots
-        # - Each label 1-63 chars
+        # RFC 1123 hostname pattern (single label only, no dots):
+        # - 1-63 chars
         # - Start/end with alphanumeric
         # - Can contain hyphens in the middle
-        pattern = (
-            r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
-            r"(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
-        )
+        pattern = r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$"
         if not re.match(pattern, v):
-            raise ValueError("Invalid hostname format (must follow RFC 1123)")
+            raise ValueError(
+                f"Invalid hostname: {v} (must be RFC 1123 compliant: "
+                f"alphanumeric and hyphens only, 1-63 chars, cannot start/end with hyphen)"
+            )
 
         return v
 
@@ -146,9 +142,7 @@ class RouterConfig(BaseModel):
     )
 
     # Routing
-    routes: Annotated[
-        RoutesConfig | None, Field(None, description="Static routing configuration")
-    ]
+    routes: Annotated[RoutesConfig | None, Field(None, description="Static routing configuration")]
     ospf: Annotated[OspfConfig | None, Field(None, description="OSPF dynamic routing")]
 
     # Services
@@ -260,9 +254,7 @@ class RouterConfig(BaseModel):
 
         for pool in self.dhcp.pools:
             if pool.interface not in interface_names:
-                raise ValueError(
-                    f"DHCP pool references non-existent interface: '{pool.interface}'"
-                )
+                raise ValueError(f"DHCP pool references non-existent interface: '{pool.interface}'")
 
         for reservation in self.dhcp.reservations:
             if reservation.interface not in interface_names:

--- a/src/vyos_onecontext/models/dhcp.py
+++ b/src/vyos_onecontext/models/dhcp.py
@@ -22,9 +22,7 @@ class DhcpPool(BaseModel):
     range_end: Annotated[IPv4Address, Field(description="Last IP in range")]
     gateway: Annotated[IPv4Address, Field(description="Default gateway for clients")]
     dns: list[IPv4Address] = Field(description="DNS servers for clients")
-    lease_time: Annotated[
-        int | None, Field(None, ge=60, description="Lease time in seconds")
-    ]
+    lease_time: Annotated[int | None, Field(None, ge=60, description="Lease time in seconds")]
     domain: Annotated[str | None, Field(None, description="Domain name for clients")]
 
     @field_validator("subnet")

--- a/src/vyos_onecontext/models/firewall.py
+++ b/src/vyos_onecontext/models/firewall.py
@@ -100,9 +100,7 @@ class FirewallRule(BaseModel):
     destination_port_group: Annotated[
         str | None, Field(None, description="Destination port group name")
     ]
-    icmp_type: Annotated[
-        str | None, Field(None, description="ICMP type name (e.g., echo-request)")
-    ]
+    icmp_type: Annotated[str | None, Field(None, description="ICMP type name (e.g., echo-request)")]
     description: Annotated[str | None, Field(None, description="Rule description")]
 
     @field_validator("source_address")
@@ -232,9 +230,7 @@ class FirewallConfig(BaseModel):
         FirewallGroups, Field(default_factory=FirewallGroups, description="Firewall groups")
     ]
     zones: dict[str, FirewallZone] = Field(default_factory=dict, description="Zone definitions")
-    policies: list[FirewallPolicy] = Field(
-        default_factory=list, description="Inter-zone policies"
-    )
+    policies: list[FirewallPolicy] = Field(default_factory=list, description="Inter-zone policies")
 
     @field_validator("zones")
     @classmethod
@@ -256,9 +252,7 @@ class FirewallConfig(BaseModel):
         # Check that policy zones exist
         for policy in self.policies:
             if policy.from_zone not in self.zones:
-                raise ValueError(
-                    f"Policy references non-existent from_zone: '{policy.from_zone}'"
-                )
+                raise ValueError(f"Policy references non-existent from_zone: '{policy.from_zone}'")
             if policy.to_zone not in self.zones:
                 raise ValueError(f"Policy references non-existent to_zone: '{policy.to_zone}'")
 

--- a/src/vyos_onecontext/models/interface.py
+++ b/src/vyos_onecontext/models/interface.py
@@ -10,9 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 # Supports: eth, bond, br (bridge), wg (wireguard), vti (VPN tunnel),
 # tun, tap, dum (dummy), peth (physical eth), and lo (loopback)
 # See: https://docs.vyos.io/en/sagitta/configuration/interfaces/index.html
-VALID_INTERFACE_PATTERN = re.compile(
-    r"^(eth|bond|br|wg|vti|tun|tap|dum|peth)\d+$|^lo$"
-)
+VALID_INTERFACE_PATTERN = re.compile(r"^(eth|bond|br|wg|vti|tun|tap|dum|peth)\d+$|^lo$")
 
 
 class InterfaceConfig(BaseModel):
@@ -28,9 +26,7 @@ class InterfaceConfig(BaseModel):
     gateway: Annotated[IPv4Address | None, Field(None, description="Default gateway")]
     dns: Annotated[IPv4Address | None, Field(None, description="DNS server")]
     mtu: Annotated[int | None, Field(None, ge=68, le=9000, description="Interface MTU")]
-    management: Annotated[
-        bool, Field(False, description="Place interface in management VRF")
-    ]
+    management: Annotated[bool, Field(False, description="Place interface in management VRF")]
 
     @field_validator("name")
     @classmethod

--- a/src/vyos_onecontext/models/routing.py
+++ b/src/vyos_onecontext/models/routing.py
@@ -133,9 +133,7 @@ class OspfConfig(BaseModel):
     def validate_enabled_consistency(self) -> "OspfConfig":
         """Warn if OSPF is disabled but has configuration."""
         if not self.enabled:
-            has_config = bool(
-                self.interfaces or self.redistribute or self.default_information
-            )
+            has_config = bool(self.interfaces or self.redistribute or self.default_information)
             if has_config:
                 raise ValueError(
                     "OSPF is disabled but has configuration (interfaces, redistribute, or "

--- a/src/vyos_onecontext/wrapper.py
+++ b/src/vyos_onecontext/wrapper.py
@@ -131,8 +131,7 @@ class VyOSConfigSession:
             )
         except FileNotFoundError:
             raise VyOSConfigError(
-                f"VyOS wrapper not found at {self.wrapper_path}. "
-                "Is this running on a VyOS system?"
+                f"VyOS wrapper not found at {self.wrapper_path}. Is this running on a VyOS system?"
             ) from None
         except OSError as e:
             raise VyOSConfigError(f"Failed to execute VyOS wrapper: {e}") from e

--- a/tests/test_integration_fixtures.py
+++ b/tests/test_integration_fixtures.py
@@ -148,9 +148,13 @@ class TestIsoCreationScript:
                 extract_result = subprocess.run(
                     [
                         "xorriso",
-                        "-osirrox", "on",
-                        "-indev", str(iso_path),
-                        "-extract", "/", str(extract_dir),
+                        "-osirrox",
+                        "on",
+                        "-indev",
+                        str(iso_path),
+                        "-extract",
+                        "/",
+                        str(extract_dir),
                     ],
                     capture_output=True,
                     text=True,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -97,7 +97,7 @@ class TestApplyConfiguration:
     ) -> None:
         """Test that parse errors return EXIT_PARSE_ERROR."""
         context_path = tmp_path / "context.sh"
-        context_path.write_text('INVALID')
+        context_path.write_text("INVALID")
 
         mock_parse.side_effect = ValueError("Parse error")
 
@@ -191,9 +191,7 @@ class TestApplyConfiguration:
         with patch("vyos_onecontext.__main__.FREEZE_MARKER_PATH", str(tmp_path / "frozen")):
             result = apply_configuration(str(context_path))
             assert result == EXIT_SUCCESS
-            mock_session.run_commands.assert_called_once_with(
-                ["set system host-name test-router"]
-            )
+            mock_session.run_commands.assert_called_once_with(["set system host-name test-router"])
             mock_session.save.assert_not_called()
 
     @patch("vyos_onecontext.__main__.VyOSConfigSession")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -498,9 +498,7 @@ class TestRouterConfig:
                 ]
             ),
             firewall=FirewallConfig(
-                zones={
-                    "WAN": FirewallZone(name="WAN", interfaces=["eth0"], default_action="drop")
-                }
+                zones={"WAN": FirewallZone(name="WAN", interfaces=["eth0"], default_action="drop")}
             ),
         )
         assert router.hostname == "router-01"
@@ -730,9 +728,7 @@ class TestValidationEnhancements:
                     FirewallPolicy(
                         from_zone="LAN",
                         to_zone="WAN",
-                        rules=[
-                            FirewallRule(action="accept", source_address_group="NONEXISTENT")
-                        ],
+                        rules=[FirewallRule(action="accept", source_address_group="NONEXISTENT")],
                     )
                 ],
             )
@@ -949,9 +945,7 @@ class TestValidationEnhancements:
             interfaces=[InterfaceConfig(name="eth1", ip="10.0.1.1", mask="255.255.255.0")],
             routes=RoutesConfig(
                 static=[
-                    StaticRoute(
-                        interface="eth1", destination="0.0.0.0/0", gateway="10.0.1.254"
-                    )
+                    StaticRoute(interface="eth1", destination="0.0.0.0/0", gateway="10.0.1.254")
                 ]
             ),
         )
@@ -983,10 +977,10 @@ class TestInputValidation:
         router = RouterConfig(hostname="router01")
         assert router.hostname == "router01"
 
-    def test_hostname_valid_fqdn(self) -> None:
-        """Test valid FQDN hostname."""
-        router = RouterConfig(hostname="router01.example.com")
-        assert router.hostname == "router01.example.com"
+    def test_hostname_invalid_fqdn(self) -> None:
+        """Test that FQDN hostname is rejected (only simple hostnames allowed)."""
+        with pytest.raises(ValidationError, match="Invalid hostname"):
+            RouterConfig(hostname="router01.example.com")
 
     def test_hostname_valid_with_hyphens(self) -> None:
         """Test valid hostname with hyphens."""
@@ -994,29 +988,29 @@ class TestInputValidation:
         assert router.hostname == "my-router-01"
 
     def test_hostname_invalid_too_long(self) -> None:
-        """Test that hostname longer than 253 chars is rejected."""
-        long_hostname = "a" * 254
-        with pytest.raises(ValidationError, match="too long"):
+        """Test that hostname longer than 63 chars is rejected."""
+        long_hostname = "a" * 64
+        with pytest.raises(ValidationError, match="Invalid hostname"):
             RouterConfig(hostname=long_hostname)
 
     def test_hostname_invalid_starts_with_hyphen(self) -> None:
         """Test that hostname starting with hyphen is rejected."""
-        with pytest.raises(ValidationError, match="Invalid hostname format"):
+        with pytest.raises(ValidationError, match="Invalid hostname"):
             RouterConfig(hostname="-router")
 
     def test_hostname_invalid_ends_with_hyphen(self) -> None:
         """Test that hostname ending with hyphen is rejected."""
-        with pytest.raises(ValidationError, match="Invalid hostname format"):
+        with pytest.raises(ValidationError, match="Invalid hostname"):
             RouterConfig(hostname="router-")
 
     def test_hostname_invalid_special_chars(self) -> None:
         """Test that hostname with special chars is rejected."""
-        with pytest.raises(ValidationError, match="Invalid hostname format"):
+        with pytest.raises(ValidationError, match="Invalid hostname"):
             RouterConfig(hostname="router_01")
 
     def test_hostname_invalid_spaces(self) -> None:
         """Test that hostname with spaces is rejected."""
-        with pytest.raises(ValidationError, match="Invalid hostname format"):
+        with pytest.raises(ValidationError, match="Invalid hostname"):
             RouterConfig(hostname="test router")
 
     def test_hostname_none_allowed(self) -> None:
@@ -1030,10 +1024,10 @@ class TestInputValidation:
             router = RouterConfig(hostname=hostname)
             assert router.hostname == hostname
 
-    def test_hostname_valid_single_char_labels_fqdn(self) -> None:
-        """Test valid FQDN with single-character labels."""
-        router = RouterConfig(hostname="a.b.c")
-        assert router.hostname == "a.b.c"
+    def test_hostname_invalid_dots(self) -> None:
+        """Test that hostname with dots is rejected (FQDN not allowed)."""
+        with pytest.raises(ValidationError, match="Invalid hostname"):
+            RouterConfig(hostname="a.b.c")
 
     def test_hostname_valid_two_chars(self) -> None:
         """Test valid two-character hostname."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -340,10 +340,10 @@ class TestOperationalVariables:
         """Test SSH public key with multiple keys (newline separated)."""
         context_file = tmp_path / "one_env"
         # Multiple SSH keys on separate lines (literal newlines in the value)
-        content = '''SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC+key1 user1@host1
+        content = """SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC+key1 user1@host1
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC+key2 user2@host2
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest3 user3@host3"
-'''
+"""
         context_file.write_text(content)
 
         config = parse_context(str(context_file))
@@ -506,9 +506,7 @@ NAT_JSON='{json.dumps(nat_data)}'
                 "address": {},
                 "port": {},
             },
-            "zones": {
-                "WAN": {"name": "WAN", "interfaces": ["eth0"], "default_action": "drop"}
-            },
+            "zones": {"WAN": {"name": "WAN", "interfaces": ["eth0"], "default_action": "drop"}},
             "policies": [],
         }
         # Need interface to satisfy RouterConfig validation
@@ -527,7 +525,7 @@ FIREWALL_JSON='{json.dumps(firewall_data)}'
     def test_malformed_json(self, tmp_path: Path) -> None:
         """Test that malformed JSON raises error."""
         context_file = tmp_path / "one_env"
-        context_file.write_text('ROUTES_JSON=\'{"invalid": json}\'\n')
+        context_file.write_text("ROUTES_JSON='{\"invalid\": json}'\n")
 
         with pytest.raises(ValueError, match="Invalid JSON"):
             parse_context(str(context_file))
@@ -536,7 +534,7 @@ FIREWALL_JSON='{json.dumps(firewall_data)}'
         """Test that JSON with invalid schema raises error."""
         context_file = tmp_path / "one_env"
         # Missing required fields
-        context_file.write_text('OSPF_JSON=\'{"interfaces": []}\'\n')
+        context_file.write_text("OSPF_JSON='{\"interfaces\": []}'\n")
 
         with pytest.raises(ValueError, match="Validation error"):
             parse_context(str(context_file))
@@ -621,10 +619,10 @@ class TestMultilineEdgeCases:
         """Test that literal newlines in multiline values are preserved."""
         context_file = tmp_path / "one_env"
         # Test that literal newlines in the file are preserved as-is
-        content = '''TEST_VAR="Line 1
+        content = """TEST_VAR="Line 1
 Line 2
 Line 3"
-'''
+"""
         context_file.write_text(content)
 
         parser = ContextParser(str(context_file))
@@ -638,12 +636,12 @@ Line 3"
     def test_empty_lines_in_multiline_value(self, tmp_path: Path) -> None:
         """Test multiline values containing empty lines."""
         context_file = tmp_path / "one_env"
-        content = '''SCRIPT="#!/bin/bash
+        content = """SCRIPT="#!/bin/bash
 
 echo 'Starting'
 
 echo 'Done'"
-'''
+"""
         context_file.write_text(content)
 
         parser = ContextParser(str(context_file))
@@ -674,10 +672,10 @@ echo 'Done'"
     def test_multiline_value_with_comment_char(self, tmp_path: Path) -> None:
         """Test multiline values containing # character (not treated as comment inside quotes)."""
         context_file = tmp_path / "one_env"
-        content = '''SCRIPT="#!/bin/bash
+        content = """SCRIPT="#!/bin/bash
 # This is a comment inside the script
 echo 'test'"
-'''
+"""
         context_file.write_text(content)
 
         parser = ContextParser(str(context_file))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -80,9 +80,7 @@ class TestSimpleRouter:
         assert any("public-keys" in cmd for cmd in commands)
 
         # Verify interface command
-        assert any(
-            "eth0" in cmd and "192.168.1.1/24" in cmd for cmd in commands
-        )
+        assert any("eth0" in cmd and "192.168.1.1/24" in cmd for cmd in commands)
 
     def test_command_format(self, config) -> None:
         """Generated commands have correct VyOS format."""
@@ -273,17 +271,13 @@ class TestFullFeatured:
         assert len(config.routes.static) == 2
 
         # Route with custom distance
-        route1 = next(
-            r for r in config.routes.static if r.destination == "192.0.2.0/24"
-        )
+        route1 = next(r for r in config.routes.static if r.destination == "192.0.2.0/24")
         assert route1.interface == "eth1"
         assert str(route1.gateway) == "198.51.100.2"
         assert route1.distance == 5
 
         # Route with default distance
-        route2 = next(
-            r for r in config.routes.static if r.destination == "172.20.0.0/16"
-        )
+        route2 = next(r for r in config.routes.static if r.destination == "172.20.0.0/16")
         assert route2.interface == "eth2"
         assert route2.distance == 1
 
@@ -330,16 +324,12 @@ class TestFullFeatured:
         assert len(config.nat.destination) == 2
 
         # HTTPS port forward
-        https_dnat = next(
-            d for d in config.nat.destination if d.destination_port == 443
-        )
+        https_dnat = next(d for d in config.nat.destination if d.destination_port == 443)
         assert str(https_dnat.translation_address) == "172.16.1.10"
         assert https_dnat.description == "HTTPS to web server"
 
         # SMTP port forward
-        smtp_dnat = next(
-            d for d in config.nat.destination if d.destination_port == 25
-        )
+        smtp_dnat = next(d for d in config.nat.destination if d.destination_port == 25)
         assert str(smtp_dnat.translation_address) == "172.16.1.20"
 
     def test_binat(self, config) -> None:
@@ -347,16 +337,12 @@ class TestFullFeatured:
         assert config.nat is not None
         assert len(config.nat.binat) == 2
 
-        binat1 = next(
-            b for b in config.nat.binat if str(b.external_address) == "198.51.100.10"
-        )
+        binat1 = next(b for b in config.nat.binat if str(b.external_address) == "198.51.100.10")
         assert str(binat1.internal_address) == "172.16.2.10"
         assert binat1.interface == "eth1"
         assert binat1.description == "DB server binat"
 
-        binat2 = next(
-            b for b in config.nat.binat if str(b.external_address) == "198.51.100.11"
-        )
+        binat2 = next(b for b in config.nat.binat if str(b.external_address) == "198.51.100.11")
         assert str(binat2.internal_address) == "172.16.2.11"
 
     def test_binat_external_address_validation(self, config) -> None:
@@ -420,9 +406,7 @@ class TestFullFeatured:
 
         # LAN to WAN policy
         lan_wan = next(
-            p
-            for p in config.firewall.policies
-            if p.from_zone == "LAN" and p.to_zone == "WAN"
+            p for p in config.firewall.policies if p.from_zone == "LAN" and p.to_zone == "WAN"
         )
         assert len(lan_wan.rules) == 3
 


### PR DESCRIPTION
Closes #34

## Summary
- Add field validator for hostname in RouterConfig
- Enforce RFC 1123 compliance for simple hostnames (single label only)
- Reject FQDNs (hostnames with dots)
- Hostnames must be alphanumeric with hyphens, 1-63 chars, cannot start/end with hyphen
- Update unit tests to reflect new validation rules

## Changes

### Validation Rules
The hostname validator now enforces:
- Length: 1-63 characters (previously allowed up to 253 for FQDNs)
- Start/end: Must be alphanumeric
- Middle: Can contain hyphens
- No dots allowed (FQDNs not supported)

### Test Updates
- `test_hostname_invalid_fqdn`: Now correctly rejects FQDNs like "router01.example.com"
- `test_hostname_invalid_dots`: Rejects simple dotted names like "a.b.c"
- `test_hostname_invalid_too_long`: Updated to test 64 chars (not 254)
- Error message tests updated to match new format

### Code Formatting
Applied ruff formatting to ensure consistent code style across the codebase.

## Test Results
All 405 tests pass:
```
uv run pytest
============================= 405 passed in 0.94s ==============================
```

---
Generated with Claude Code (Opus 4.5)