### PR TITLE
feat(models): Restrict interface validation to eth interfaces only

### DIFF
--- a/src/vyos_onecontext/models/interface.py
+++ b/src/vyos_onecontext/models/interface.py
@@ -24,7 +24,7 @@ def _validate_interface_name(name: str) -> str:
     Raises:
         ValueError: If interface name is invalid
     """
-    if not VALID_INTERFACE_PATTERN.match(name):
+    if not VALID_INTERFACE_PATTERN.fullmatch(name):
         raise ValueError(
             f"Invalid interface name '{name}' (expected ethN format, e.g., eth0, eth1)"
         )

--- a/src/vyos_onecontext/models/interface.py
+++ b/src/vyos_onecontext/models/interface.py
@@ -12,6 +12,25 @@ from pydantic import BaseModel, Field, field_validator
 VALID_INTERFACE_PATTERN = re.compile(r"^eth\d+$")
 
 
+def _validate_interface_name(name: str) -> str:
+    """Validate interface name follows expected pattern.
+
+    Args:
+        name: Interface name to validate
+
+    Returns:
+        The validated interface name
+
+    Raises:
+        ValueError: If interface name is invalid
+    """
+    if not VALID_INTERFACE_PATTERN.match(name):
+        raise ValueError(
+            f"Invalid interface name '{name}' (expected ethN format, e.g., eth0, eth1)"
+        )
+    return name
+
+
 class InterfaceConfig(BaseModel):
     """Configuration for a network interface.
 
@@ -30,22 +49,8 @@ class InterfaceConfig(BaseModel):
     @field_validator("name")
     @classmethod
     def validate_interface_name(cls, v: str) -> str:
-        """Validate interface name follows expected pattern.
-
-        Args:
-            v: Interface name to validate
-
-        Returns:
-            The validated interface name
-
-        Raises:
-            ValueError: If interface name is invalid
-        """
-        if not VALID_INTERFACE_PATTERN.match(v):
-            raise ValueError(
-                f"Invalid interface name '{v}' (expected ethN format, e.g., eth0, eth1)"
-            )
-        return v
+        """Validate interface name follows expected pattern."""
+        return _validate_interface_name(v)
 
     @field_validator("mask")
     @classmethod
@@ -97,22 +102,8 @@ class AliasConfig(BaseModel):
     @field_validator("interface")
     @classmethod
     def validate_interface_name(cls, v: str) -> str:
-        """Validate parent interface name follows expected pattern.
-
-        Args:
-            v: Interface name to validate
-
-        Returns:
-            The validated interface name
-
-        Raises:
-            ValueError: If interface name is invalid
-        """
-        if not VALID_INTERFACE_PATTERN.match(v):
-            raise ValueError(
-                f"Invalid interface name '{v}' (expected ethN format, e.g., eth0, eth1)"
-            )
-        return v
+        """Validate parent interface name follows expected pattern."""
+        return _validate_interface_name(v)
 
     @field_validator("mask")
     @classmethod

--- a/src/vyos_onecontext/models/interface.py
+++ b/src/vyos_onecontext/models/interface.py
@@ -6,11 +6,10 @@ from typing import Annotated
 
 from pydantic import BaseModel, Field, field_validator
 
-# Pattern for valid VyOS interface names (VyOS 1.4 Sagitta)
-# Supports: eth, bond, br (bridge), wg (wireguard), vti (VPN tunnel),
-# tun, tap, dum (dummy), peth (physical eth), and lo (loopback)
-# See: https://docs.vyos.io/en/sagitta/configuration/interfaces/index.html
-VALID_INTERFACE_PATTERN = re.compile(r"^(eth|bond|br|wg|vti|tun|tap|dum|peth)\d+$|^lo$")
+# Pattern for valid interface names in OpenNebula context
+# OpenNebula provides only ETHx variables, so we only support eth interfaces.
+# VLAN subinterfaces (e.g., eth0.100) are not yet supported (see issue #46).
+VALID_INTERFACE_PATTERN = re.compile(r"^eth\d+$")
 
 
 class InterfaceConfig(BaseModel):
@@ -44,8 +43,7 @@ class InterfaceConfig(BaseModel):
         """
         if not VALID_INTERFACE_PATTERN.match(v):
             raise ValueError(
-                f"Invalid interface name '{v}'. Supported types: "
-                "eth, bond, br, wg, vti, tun, tap, dum, peth (with number), or lo"
+                f"Invalid interface name '{v}' (expected ethN format, e.g., eth0, eth1)"
             )
         return v
 
@@ -112,8 +110,7 @@ class AliasConfig(BaseModel):
         """
         if not VALID_INTERFACE_PATTERN.match(v):
             raise ValueError(
-                f"Invalid interface name '{v}'. Supported types: "
-                "eth, bond, br, wg, vti, tun, tap, dum, peth (with number), or lo"
+                f"Invalid interface name '{v}' (expected ethN format, e.g., eth0, eth1)"
             )
         return v
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1135,45 +1135,50 @@ class TestInputValidation:
         iface = InterfaceConfig(name="eth99", ip="10.0.1.1", mask="255.255.255.0")
         assert iface.name == "eth99"
 
-    def test_interface_name_valid_bond(self) -> None:
-        """Test valid bond interface name."""
-        iface = InterfaceConfig(name="bond0", ip="10.0.1.1", mask="255.255.255.0")
-        assert iface.name == "bond0"
-
-    def test_interface_name_valid_bridge(self) -> None:
-        """Test valid bridge interface name."""
-        iface = InterfaceConfig(name="br0", ip="10.0.1.1", mask="255.255.255.0")
-        assert iface.name == "br0"
-
-    def test_interface_name_valid_wireguard(self) -> None:
-        """Test valid wireguard interface name."""
-        iface = InterfaceConfig(name="wg0", ip="10.0.1.1", mask="255.255.255.0")
-        assert iface.name == "wg0"
-
-    def test_interface_name_valid_vti(self) -> None:
-        """Test valid VPN tunnel interface name."""
-        iface = InterfaceConfig(name="vti0", ip="10.0.1.1", mask="255.255.255.0")
-        assert iface.name == "vti0"
-
-    def test_interface_name_valid_tun(self) -> None:
-        """Test valid tun interface name."""
-        iface = InterfaceConfig(name="tun0", ip="10.0.1.1", mask="255.255.255.0")
-        assert iface.name == "tun0"
-
-    def test_interface_name_valid_tap(self) -> None:
-        """Test valid tap interface name."""
-        iface = InterfaceConfig(name="tap0", ip="10.0.1.1", mask="255.255.255.0")
-        assert iface.name == "tap0"
-
-    def test_interface_name_valid_loopback(self) -> None:
-        """Test valid loopback interface name."""
-        iface = InterfaceConfig(name="lo", ip="127.0.0.1", mask="255.0.0.0")
-        assert iface.name == "lo"
-
-    def test_interface_name_invalid_unknown_type(self) -> None:
-        """Test that unknown interface types are rejected."""
+    def test_interface_name_invalid_bond(self) -> None:
+        """Test that bond interface is rejected (not supported by ONE context)."""
         with pytest.raises(ValidationError, match="Invalid interface name"):
-            InterfaceConfig(name="eno1", ip="10.0.1.1", mask="255.255.255.0")
+            InterfaceConfig(name="bond0", ip="10.0.1.1", mask="255.255.255.0")
+
+    def test_interface_name_invalid_bridge(self) -> None:
+        """Test that bridge interface is rejected (not supported by ONE context)."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            InterfaceConfig(name="br0", ip="10.0.1.1", mask="255.255.255.0")
+
+    def test_interface_name_invalid_wireguard(self) -> None:
+        """Test that wireguard interface is rejected (not supported by ONE context)."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            InterfaceConfig(name="wg0", ip="10.0.1.1", mask="255.255.255.0")
+
+    def test_interface_name_invalid_vti(self) -> None:
+        """Test that VPN tunnel interface is rejected (not supported by ONE context)."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            InterfaceConfig(name="vti0", ip="10.0.1.1", mask="255.255.255.0")
+
+    def test_interface_name_invalid_tun(self) -> None:
+        """Test that tun interface is rejected (not supported by ONE context)."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            InterfaceConfig(name="tun0", ip="10.0.1.1", mask="255.255.255.0")
+
+    def test_interface_name_invalid_tap(self) -> None:
+        """Test that tap interface is rejected (not supported by ONE context)."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            InterfaceConfig(name="tap0", ip="10.0.1.1", mask="255.255.255.0")
+
+    def test_interface_name_invalid_loopback(self) -> None:
+        """Test that loopback interface is rejected (not supported by ONE context)."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            InterfaceConfig(name="lo", ip="127.0.0.1", mask="255.0.0.0")
+
+    def test_interface_name_invalid_ens(self) -> None:
+        """Test that ens-style interface is rejected."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            InterfaceConfig(name="ens3", ip="10.0.1.1", mask="255.255.255.0")
+
+    def test_interface_name_invalid_enp(self) -> None:
+        """Test that enp-style interface is rejected."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            InterfaceConfig(name="enp0s3", ip="10.0.1.1", mask="255.255.255.0")
 
     def test_interface_name_invalid_no_number(self) -> None:
         """Test that interface name without number is rejected."""
@@ -1184,6 +1189,11 @@ class TestInputValidation:
         """Test that interface name with special chars is rejected."""
         with pytest.raises(ValidationError, match="Invalid interface name"):
             InterfaceConfig(name="eth_0", ip="10.0.1.1", mask="255.255.255.0")
+
+    def test_interface_name_invalid_vlan_subinterface(self) -> None:
+        """Test that VLAN subinterface is rejected (deferred to issue #46)."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            InterfaceConfig(name="eth0.100", ip="10.0.1.1", mask="255.255.255.0")
 
     def test_alias_interface_name_valid(self) -> None:
         """Test valid alias interface name."""


### PR DESCRIPTION
Closes #35

## Summary

- Restrict interface name validation to `eth\d+` pattern only
- OpenNebula context provides only ETHx variables, so other interface types (bond, br, wg, vti, tun, tap, lo) are not supported
- Update error messages to reflect new restriction
- Convert existing tests for non-eth interfaces to negative tests
- Add tests for invalid interface types (ens3, enp0s3, eth0.100)

## Rationale

The previous validation pattern accepted multiple interface types (bond, br, wg, vti, tun, tap, dum, peth, lo), but OpenNebula contextualization only provides ETHx variables. Accepting other interface types gave a false impression of what the system can handle.

This change aligns the validation with the actual capabilities of OpenNebula context.

## Test Plan

- All existing tests pass (407 tests)
- `just check` passes (lint, typecheck, test)
- New negative tests verify that non-eth interfaces are rejected
- Valid eth interfaces (eth0, eth1, eth99) continue to work

## Notes

VLAN subinterfaces (e.g., eth0.100) are explicitly rejected and deferred to issue #46.

---
Generated with Claude Code (Opus 4.5)