### PR TITLE
feat: Implement START_CONFIG custom command injection (Phase 7.1)

### DIFF
--- a/src/vyos_onecontext/generators/__init__.py
+++ b/src/vyos_onecontext/generators/__init__.py
@@ -6,6 +6,7 @@ configuration (interfaces, routing, NAT, etc.).
 """
 
 from vyos_onecontext.generators.base import BaseGenerator
+from vyos_onecontext.generators.custom import StartConfigGenerator
 from vyos_onecontext.generators.dhcp import DhcpGenerator
 from vyos_onecontext.generators.firewall import FirewallGenerator
 from vyos_onecontext.generators.interface import InterfaceGenerator
@@ -67,9 +68,11 @@ def generate_config(config: RouterConfig) -> list[str]:
     # Firewall (groups, zones, global state policy, inter-zone policies)
     commands.extend(FirewallGenerator(config.firewall).generate())
 
+    # Custom config (START_CONFIG) - executed last, before commit
+    commands.extend(StartConfigGenerator(config.start_config).generate())
+
     # Future generators will be added here in later phases:
     # - DNS service (recursive resolver, forwarding)
-    # - Custom config (START_CONFIG)
 
     return commands
 
@@ -85,6 +88,7 @@ __all__ = [
     "RoutingGenerator",
     "SshKeyGenerator",
     "SshServiceGenerator",
+    "StartConfigGenerator",
     "StaticRoutesGenerator",
     "VrfGenerator",
     "VRF_NAME",

--- a/src/vyos_onecontext/generators/custom.py
+++ b/src/vyos_onecontext/generators/custom.py
@@ -1,0 +1,48 @@
+"""Custom configuration generators (START_CONFIG, START_SCRIPT)."""
+
+from vyos_onecontext.generators.base import BaseGenerator
+
+
+class StartConfigGenerator(BaseGenerator):
+    """Generate VyOS commands from START_CONFIG escape hatch.
+
+    START_CONFIG allows operators to inject raw VyOS commands that will be
+    executed after all generated configuration, but before commit.
+
+    Commands are executed within the same configuration transaction as the
+    generated config. No validation is performed on command syntax - operators
+    are trusted to provide valid commands.
+    """
+
+    def __init__(self, start_config: str | None):
+        """Initialize START_CONFIG generator.
+
+        Args:
+            start_config: Newline-separated VyOS commands, or None to skip
+        """
+        self.start_config = start_config
+
+    def generate(self) -> list[str]:
+        """Generate START_CONFIG commands.
+
+        Splits the START_CONFIG string on newlines and filters out empty lines
+        and comments.
+
+        Returns:
+            List of VyOS commands (typically 'set' commands) to execute
+        """
+        if self.start_config is None:
+            return []
+
+        commands: list[str] = []
+        for line in self.start_config.splitlines():
+            # Strip whitespace
+            line = line.strip()
+
+            # Skip empty lines and comments
+            if not line or line.startswith("#"):
+                continue
+
+            commands.append(line)
+
+        return commands


### PR DESCRIPTION
## Summary

Implements START_CONFIG context variable to allow operators to inject raw VyOS commands after the generated configuration.

## Changes

- Add `StartConfigGenerator` class in `src/vyos_onecontext/generators/custom.py`
- Integrate generator into `generate_config()` (executes last, before commit)
- Parse START_CONFIG from context (already implemented in parser.py and models)
- Commands execute in same config session as generated commands
- Skip empty lines and comments in START_CONFIG

## Testing

- 8 new unit tests covering all edge cases
- All 413 tests pass
- All quality checks pass (ruff, mypy, pytest)

## Example Usage

```bash
START_CONFIG="set system ntp server pool.ntp.org
set system time-zone America/Chicago
set service lldp interface all"
```

Closes #87

---

Generated with Claude Code (Opus 4.5)