### PR TITLE
fix: address integration test network flake (#108)

### DIFF
--- a/packer/test-image.pkr.hcl
+++ b/packer/test-image.pkr.hcl
@@ -126,7 +126,7 @@ build {
       # =======================================================================
       # DNS DIAGNOSTIC INSTRUMENTATION
       # This captures DNS state at key points to debug intermittent failures.
-      # See: https://github.com/SouthwestCCDC/vyos-onecontext/issues/TBD
+      # See: https://github.com/SouthwestCCDC/vyos-onecontext/issues/108
       # =======================================================================
       <<-DIAG
       dns_diag() {
@@ -140,9 +140,6 @@ build {
         echo ""
         echo "--- /etc/gai.conf ---"
         cat /etc/gai.conf 2>/dev/null || echo "(file not found or empty)"
-        echo ""
-        echo "--- vyos-hostsd-client state ---"
-        sudo /usr/bin/vyos-hostsd-client --show-name-servers 2>&1 || echo "(command failed)"
         echo ""
         echo "--- Network interfaces ---"
         ip -4 addr show 2>/dev/null | grep -E "^[0-9]+:|inet " || echo "(no IPv4 addresses)"
@@ -176,6 +173,10 @@ build {
       "echo 'Calling vyos-hostsd-client to add DNS server...'",
       "sudo /usr/bin/vyos-hostsd-client --add-name-servers 10.0.2.3 --tag system --apply",
       "echo 'vyos-hostsd-client completed with exit code: '$?",
+      # Wait for vyos-hostsd to settle and avoid triggering network reconfiguration
+      # See: https://github.com/SouthwestCCDC/vyos-onecontext/issues/108
+      "echo 'Waiting for vyos-hostsd to settle...'",
+      "sleep 5",
       # Capture state after vyos-hostsd-client
       "dns_diag 'AFTER vyos-hostsd-client'",
       # Prefer IPv4 over IPv6 (QEMU SLIRP doesn't support IPv6)
@@ -209,9 +210,6 @@ build {
         echo "--- /etc/gai.conf ---"
         cat /etc/gai.conf 2>/dev/null || echo "(file not found or empty)"
         echo ""
-        echo "--- vyos-hostsd-client state ---"
-        sudo /usr/bin/vyos-hostsd-client --show-name-servers 2>&1 || echo "(command failed)"
-        echo ""
         echo "--- Network interfaces ---"
         ip -4 addr show 2>/dev/null | grep -E "^[0-9]+:|inet " || echo "(no IPv4 addresses)"
         echo ""
@@ -237,6 +235,38 @@ build {
         echo ""
       }
       DIAG
+      ,
+      # =======================================================================
+      # NETWORK VERIFICATION
+      # Ensure network is up before attempting downloads. Sometimes eth0
+      # disappears between provisioners due to DHCP/vyos-hostsd interactions.
+      # See: https://github.com/SouthwestCCDC/vyos-onecontext/issues/108
+      # =======================================================================
+      <<-NETWAIT
+      echo "Verifying network connectivity before proceeding..."
+      for attempt in $(seq 1 30); do
+        # Check if eth0 exists and has an IP
+        if ip -4 addr show eth0 2>/dev/null | grep -q "inet "; then
+          # Check if default route exists
+          if ip -4 route show default 2>/dev/null | grep -q "default"; then
+            echo "Network is ready (attempt $attempt/30)"
+            break
+          else
+            echo "Waiting for default route (attempt $attempt/30)..."
+          fi
+        else
+          echo "Waiting for eth0 interface (attempt $attempt/30)..."
+        fi
+
+        if [ "$attempt" -eq 30 ]; then
+          echo "ERROR: Network failed to come up after 30 attempts"
+          dns_diag 'NETWORK VERIFICATION FAILED'
+          exit 1
+        fi
+
+        sleep 2
+      done
+      NETWAIT
       ,
       # Capture DNS state at start of this provisioner
       "dns_diag 'START OF UV INSTALL PROVISIONER'",


### PR DESCRIPTION
## Summary

Addresses #108 - Integration test flake where network interface disappears between Packer provisioners.

## Changes

- **Remove invalid diagnostic flag**: The `--show-name-servers` flag doesn't exist in vyos-hostsd-client. Removed from both diagnostic functions.

- **Add stabilization wait**: 5-second sleep after `vyos-hostsd-client --apply` to allow DNS reconfiguration to settle before the next provisioner starts.

- **Add network verification loop**: Before attempting uv installation, verify that:
  - `eth0` interface exists and has an IPv4 address
  - Default route exists
  - Waits up to 60 seconds (30 attempts × 2 seconds) for network to come up

## Root Cause Theory

The flake occurs due to a race condition between:
1. `vyos-hostsd-client --apply` triggering DNS reconfiguration
2. VyOS DHCP client behavior
3. Packer opening a new SSH session for the next provisioner

When timing is unlucky, `eth0` disappears during the transition.

## Testing

This fix should be validated across multiple CI runs since the issue is intermittent. Success criteria:
- CI passes consistently (5+ runs)
- Network verification loop rarely has to wait (indicates race condition mitigation is working)

---
Generated with Claude Code (Opus 4.5)