### PR TITLE
Refactor START_SCRIPT whitespace tests to use pytest.mark.parametrize

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -122,18 +122,18 @@ class TestRunStartScript:
             assert mock_run.call_args[1]["timeout"] == 60
 
     @pytest.mark.parametrize(
-        ("whitespace_pattern", "test_id"),
+        "whitespace_pattern",
         [
-            ("  {path}", "leading"),
-            ("{path}  ", "trailing"),
-            ("  {path}  ", "both"),
+            "  {path}",
+            "{path}  ",
+            "  {path}  ",
         ],
+        ids=["leading", "trailing", "both"],
     )
     def test_run_start_script_path_with_whitespace(
         self,
         tmp_path: Path,
         whitespace_pattern: str,
-        test_id: str,
     ) -> None:
         """Test START_SCRIPT handles file paths with various whitespace patterns."""
         # Create a test script file

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -121,48 +121,27 @@ class TestRunStartScript:
             # Verify timeout parameter was passed
             assert mock_run.call_args[1]["timeout"] == 60
 
-    def test_run_start_script_path_with_leading_whitespace(self, tmp_path: Path) -> None:
-        """Test START_SCRIPT handles file paths with leading whitespace."""
+    @pytest.mark.parametrize(
+        ("whitespace_pattern", "test_id"),
+        [
+            ("  {path}", "leading"),
+            ("{path}  ", "trailing"),
+            ("  {path}  ", "both"),
+        ],
+    )
+    def test_run_start_script_path_with_whitespace(
+        self,
+        tmp_path: Path,
+        whitespace_pattern: str,
+        test_id: str,
+    ) -> None:
+        """Test START_SCRIPT handles file paths with various whitespace patterns."""
         # Create a test script file
         script_file = tmp_path / "test_script.sh"
         script_file.write_text("#!/bin/bash\necho 'from file'")
 
-        # Add leading whitespace to the path
-        script_content = f"  {script_file}"
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="from file", stderr="")
-            run_start_script(script_content)
-            mock_run.assert_called_once()
-            # Should execute the file directly (whitespace stripped)
-            call_args = mock_run.call_args[0][0]
-            assert call_args[1] == str(script_file)
-
-    def test_run_start_script_path_with_trailing_whitespace(self, tmp_path: Path) -> None:
-        """Test START_SCRIPT handles file paths with trailing whitespace."""
-        # Create a test script file
-        script_file = tmp_path / "test_script.sh"
-        script_file.write_text("#!/bin/bash\necho 'from file'")
-
-        # Add trailing whitespace to the path
-        script_content = f"{script_file}  "
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="from file", stderr="")
-            run_start_script(script_content)
-            mock_run.assert_called_once()
-            # Should execute the file directly (whitespace stripped)
-            call_args = mock_run.call_args[0][0]
-            assert call_args[1] == str(script_file)
-
-    def test_run_start_script_path_with_both_whitespace(self, tmp_path: Path) -> None:
-        """Test START_SCRIPT handles file paths with leading and trailing whitespace."""
-        # Create a test script file
-        script_file = tmp_path / "test_script.sh"
-        script_file.write_text("#!/bin/bash\necho 'from file'")
-
-        # Add both leading and trailing whitespace to the path
-        script_content = f"  {script_file}  "
+        # Apply the whitespace pattern to the path
+        script_content = whitespace_pattern.format(path=script_file)
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="from file", stderr="")


### PR DESCRIPTION
## Summary

- Consolidates three repetitive START_SCRIPT whitespace handling tests into a single parametrized test
- Reduces code duplication from 50 lines to 27 lines
- Makes it easier to add additional whitespace test cases in the future
- All three test cases are preserved with identical behavior

## Changes

Replaced these three tests:
- `test_run_start_script_path_with_leading_whitespace`
- `test_run_start_script_path_with_trailing_whitespace`
- `test_run_start_script_path_with_both_whitespace`

With a single parametrized test:
- `test_run_start_script_path_with_whitespace` using `pytest.mark.parametrize`

Each test case is identified by a clear test_id (leading, trailing, both) for easy debugging.

## Test Results

All 457 tests pass:
- Full test suite: PASSED
- Ruff linting: PASSED
- Mypy type checking: PASSED

Closes #107

Generated with Claude Code (Sonnet 4.5)