### PR TITLE
fix: refactor session management to ensure save() runs within active session

### DIFF
--- a/src/vyos_onecontext/__main__.py
+++ b/src/vyos_onecontext/__main__.py
@@ -286,7 +286,17 @@ def apply_configuration(
                         "Configuration applied, saved, and frozen "
                         "(onecontext disabled for future boots)"
                     )
-                session.save()
+                try:
+                    session.save()
+                except VyOSConfigError as e:
+                    logger.error("Failed to save configuration: %s", e)
+                    error_collector.add_error(
+                        section="CONFIG_SAVE",
+                        message="Failed to save configuration",
+                        exception=e,
+                    )
+                    error_collector.log_summary()
+                    return EXIT_CONFIG_ERROR
                 if mode == OnecontextMode.FREEZE:
                     create_freeze_marker()
             else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -434,11 +434,12 @@ class TestApplyConfiguration:
 
         mock_config = MagicMock()
         mock_config.onecontext_mode = OnecontextMode.STATELESS
+        mock_config.start_script = None
         mock_parse.return_value = mock_config
         mock_generate.return_value = ["set system host-name test-router"]
 
         mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(side_effect=VyOSConfigError("Config failed"))
+        mock_session.begin.side_effect = VyOSConfigError("Config failed")
         mock_session_class.return_value = mock_session
 
         with patch("vyos_onecontext.__main__.FREEZE_MARKER_PATH", str(tmp_path / "frozen")):


### PR DESCRIPTION
## Summary

Fixes the failing `start-script.env` integration test on sagitta branch after PR #125 merge.

**Root Cause**: The `session.save()` call was executing after the context manager had closed the VyOS configuration session. While VyOS's `save` command can technically run outside a session, this may cause timing or state issues on VyOS Sagitta that result in "Unknown error" commit failures.

**Fix**: Refactored session management in `apply_configuration()` to use manual `begin()`/`end()` calls instead of the context manager. This ensures `save()` is called while the session is still active.

## Changes

- Modified `src/vyos_onecontext/__main__.py`:
  - Replaced context manager (`with session:`) with manual session management
  - Moved `session.save()` calls to execute before `session.end()`
  - Consolidated mode handling (STATELESS/SAVE/FREEZE) inside session try/finally block

- Updated `tests/test_main.py`:
  - Changed `test_apply_configuration_config_error` to mock `begin()` instead of `__enter__()`
  - Added `mock_config.start_script = None` to prevent MagicMock type errors

## Test plan

- [x] All unit tests pass locally (475 passed, 10 skipped)
- [x] All quality checks pass (`just check`)
- [ ] Integration tests pass in CI (especially `start-script.env`)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.5)