### PR TITLE
docs: require validation of new test fixtures before merge

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -175,3 +175,22 @@ To add a new test scenario:
 
 For custom validation, modify `run-qemu-test.sh` to check specific
 configuration elements.
+
+### Validating New Fixtures Before Merge
+
+**IMPORTANT**: New test fixtures MUST be validated before adding them to the
+`TEST_SCENARIOS` array in `run-all-tests.sh` and merging.
+
+With selective testing enabled (see CI Integration above), new fixtures may not
+run during PR CI if they're not mapped to changed code paths in
+`.github/test-mapping.yml`. This means a new fixture could be added to the repo
+but never actually execute until after merge, potentially introducing broken tests.
+
+**Before merging a PR that adds a new test fixture:**
+
+1. **Run the fixture locally** using the steps in "Running Tests Locally" above, OR
+2. **Add the fixture to test-mapping.yml** for the relevant code paths it exercises,
+   ensuring it runs during PR CI
+
+This validation requirement was added after PR #125 introduced `start-script.env`,
+which was added to `TEST_SCENARIOS` but never ran until post-merge, where it failed.


### PR DESCRIPTION
## Summary

Documents the requirement that new test fixtures must be validated before being added to `TEST_SCENARIOS` in `run-all-tests.sh` and merged.

## Context

PR #125 added `start-script.env` to `TEST_SCENARIOS` but it never actually ran during PR CI due to selective testing (it wasn't mapped to changed code paths). The fixture failed when it finally ran post-merge.

## Changes

- Added "Validating New Fixtures Before Merge" subsection to `tests/integration/README.md`
- Documents two validation options:
  1. Run the fixture locally before merge
  2. Add it to `.github/test-mapping.yml` for relevant code paths
- Explains why this is necessary with selective testing enabled

## Test plan

- [x] Documentation change only
- [x] Verified formatting and clarity

Generated with [Claude Code](https://claude.com/claude-code)