### PR TITLE
docs: add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # vyos-onecontext
 
+![CI](https://github.com/SouthwestCCDC/vyos-onecontext/actions/workflows/ci.yml/badge.svg?branch=sagitta)
+
 OpenNebula contextualization for VyOS Sagitta (1.4.x) router images.
 
 ## Overview


### PR DESCRIPTION
## Summary

Add a GitHub Actions CI status badge to the README for visibility into build status.

## Changes

- Added CI workflow status badge after the title in README.md
- Badge shows status specifically for the sagitta branch

## Motivation

After PR #125 introduced a failing test that wasn't discovered until after merge, it became clear that CI status visibility is important. This badge provides at-a-glance status on the repo homepage.

## Test plan

- [x] Badge syntax is correct
- [x] Badge points to correct workflow and branch

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Sonnet 4.5)