### PR TITLE
Make CI badge clickable to workflows page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # vyos-onecontext
 
+[![CI](https://github.com/SouthwestCCDC/vyos-onecontext/actions/workflows/ci.yml/badge.svg?branch=sagitta)](https://github.com/SouthwestCCDC/vyos-onecontext/actions/workflows/ci.yml)
+
 OpenNebula contextualization for VyOS Sagitta (1.4.x) router images.
 
 ## Overview


### PR DESCRIPTION
## Summary

- Added clickable link to the CI badge in README.md
- Badge now links to GitHub Actions workflows page instead of just displaying as a static image

Closes #130

## Test Plan

- [x] Verify markdown syntax is correct
- [ ] View README on GitHub to confirm badge is clickable
- [ ] Click badge to verify it navigates to workflows page

Generated with Claude Code (Sonnet 4.5)