### PR TITLE
test(integration): enable error scenario integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,10 @@ addopts = [
 markers = [
     "integration: marks tests as integration tests (require VyOS VM)",
 ]
+
+[dependency-groups]
+dev = [
+    "mypy>=1.19.1",
+    "pytest>=9.0.2",
+    "ruff>=0.14.11",
+]

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -65,6 +65,20 @@ Test context files are in `contexts/`:
 - **nat-with-firewall.env**: NAT with zone-based firewall
 - **start-script.env**: START_SCRIPT post-configuration script execution
 
+### Error Scenarios
+
+Error scenario fixtures test graceful error handling:
+
+- **invalid-json.env**: Malformed JSON in ROUTES_JSON (tests JSON parse error handling)
+- **missing-required-fields.env**: OSPF_JSON missing required 'enabled' field (tests Pydantic validation)
+- **partial-valid.env**: Multiple errors across different sections (tests error accumulation)
+
+These scenarios validate that:
+- Valid configuration sections are still applied when other sections fail
+- Errors are collected and logged with clear messages
+- An ERROR SUMMARY is generated
+- Exit code 1 is returned (indicating errors) but boot completes successfully
+
 ## CI Integration
 
 In CI, these tests run on self-hosted KVM runners with selective testing based on

--- a/tests/integration/run-all-tests.sh
+++ b/tests/integration/run-all-tests.sh
@@ -47,6 +47,9 @@ declare -a TEST_SCENARIOS=(
     "vrf-with-routing:VRF with routing (VRF+static+OSPF)"
     "nat-with-firewall:NAT with firewall zones"
     "start-script:START_SCRIPT execution"
+    "invalid-json:Error scenario - Invalid JSON"
+    "missing-required-fields:Error scenario - Missing required fields"
+    "partial-valid:Error scenario - Partial valid config"
 )
 
 TEMP_DIR=$(mktemp -d)

--- a/uv.lock
+++ b/uv.lock
@@ -366,6 +366,13 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
@@ -374,3 +381,10 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.19.1" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.14.11" },
+]


### PR DESCRIPTION
## Summary

- Wires existing error fixtures (`invalid-json`, `missing-required-fields`, `partial-valid`) into integration test runner
- Validates graceful error handling at runtime, not just parse time
- Tests that valid config sections are applied even when other sections fail

## Test plan

- [x] `just check` passes (478 tests)
- [x] Error fixtures added to run-all-tests.sh
- [ ] Integration CI validates error scenarios behave correctly

Generated with Claude Code (Opus 4.5)