### PR TITLE
feat(ai): add shared context files and Copilot agents

### DIFF
--- a/.ai/context/commit-conventions.md
+++ b/.ai/context/commit-conventions.md
@@ -1,0 +1,66 @@
+# Commit Conventions
+
+## Message Format
+
+```
+type(area): brief description
+
+Addresses #ISSUE_NUMBER
+
+Co-Authored-By: Claude {Model} <noreply@anthropic.com>
+```
+
+## Types
+
+| Type | Use For |
+|------|---------|
+| `feat` | New functionality |
+| `fix` | Bug fixes |
+| `refactor` | Code restructuring without behavior change |
+| `test` | Adding or updating tests |
+| `docs` | Documentation changes |
+| `chore` | Build, CI, tooling changes |
+
+## Areas
+
+| Area | Scope |
+|------|-------|
+| `generator` | Configuration generators |
+| `parser` | Context JSON parsing |
+| `model` | Pydantic models |
+| `cli` | Command-line interface |
+| `test` | Test infrastructure |
+
+## AI Disclosure
+
+All AI-generated commits MUST include the co-author trailer:
+
+```
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+Use the actual model (Sonnet 4.5, Opus 4.5, Haiku, etc.).
+
+## Examples
+
+```
+feat(generator): implement DHCP pool configuration
+
+Adds support for parsing DHCP_JSON context variable and generating
+VyOS DHCP server configuration.
+
+Addresses #15
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+```
+fix(parser): handle missing optional fields gracefully
+
+Return default values instead of raising KeyError when optional
+context fields are absent.
+
+Addresses #23
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```

--- a/.ai/context/commit-conventions.md
+++ b/.ai/context/commit-conventions.md
@@ -7,7 +7,7 @@ type(area): brief description
 
 Addresses #ISSUE_NUMBER
 
-Co-authored-by: {AI Tool/Model} <noreply@anthropic.com>
+Co-authored-by: {AI Tool/Model} <{AI email}>
 ```
 
 ## Types
@@ -36,8 +36,13 @@ Co-authored-by: {AI Tool/Model} <noreply@anthropic.com>
 All AI-generated commits MUST include the co-author trailer:
 
 ```
-Co-authored-by: {AI Tool/Model} <noreply@anthropic.com>
+Co-authored-by: {AI Tool/Model} <{AI email}>
 ```
+
+Use tool-appropriate email domains:
+- Claude (any model): `<noreply@anthropic.com>`
+- GitHub Copilot: `<noreply@github.com>`
+- Other tools: Use appropriate domain or `<{AI email}>` as placeholder
 
 Examples: `Claude Sonnet 4.5`, `GitHub Copilot`, `Claude Opus 4.5`, etc.
 
@@ -62,7 +67,7 @@ context fields are absent.
 
 Addresses #23
 
-Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>
+Co-authored-by: GitHub Copilot <noreply@github.com>
 ```
 
 ---

--- a/.ai/context/commit-conventions.md
+++ b/.ai/context/commit-conventions.md
@@ -7,7 +7,7 @@ type(area): brief description
 
 Addresses #ISSUE_NUMBER
 
-Co-Authored-By: Claude {Model} <noreply@anthropic.com>
+Co-authored-by: {AI Tool/Model} <noreply@anthropic.com>
 ```
 
 ## Types
@@ -36,10 +36,10 @@ Co-Authored-By: Claude {Model} <noreply@anthropic.com>
 All AI-generated commits MUST include the co-author trailer:
 
 ```
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+Co-authored-by: {AI Tool/Model} <noreply@anthropic.com>
 ```
 
-Use the actual model (Sonnet 4.5, Opus 4.5, Haiku, etc.).
+Examples: `Claude Sonnet 4.5`, `GitHub Copilot`, `Claude Opus 4.5`, etc.
 
 ## Examples
 
@@ -51,7 +51,7 @@ VyOS DHCP server configuration.
 
 Addresses #15
 
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>
 ```
 
 ```
@@ -62,5 +62,8 @@ context fields are absent.
 
 Addresses #23
 
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>
 ```
+
+---
+*Generated with Claude Code assistance.*

--- a/.ai/context/pr-comment-handling.md
+++ b/.ai/context/pr-comment-handling.md
@@ -1,0 +1,61 @@
+# PR Comment Handling
+
+## Proactive Check After Push
+
+After pushing changes to a PR, check for review comments:
+
+```bash
+gh api repos/SouthwestCCDC/vyos-onecontext/pulls/{N}/comments --jq '.[].body' | head -20
+```
+
+## Response Workflow
+
+When review comments exist:
+
+1. **Read and understand** each comment
+2. **Address the issue** in your worktree
+3. **Commit and push** the fix
+4. **Reply to the comment** (see below)
+5. **Re-check** for new comments
+
+Work is not complete until all comments are addressed and replied to.
+
+## Replying to Comments
+
+Every addressed comment needs an inline reply with AI disclosure:
+
+```bash
+gh api repos/SouthwestCCDC/vyos-onecontext/pulls/{N}/comments/{comment_id}/replies \
+  -f body="Fixed in {SHA}. {brief explanation}
+
+(AI-generated via Claude Code w/ {Model})"
+```
+
+## Comment Categories
+
+When triaging comments:
+
+| Category | Meaning | Action |
+|----------|---------|--------|
+| **A: Fix Now** | Valid issue for this PR | Implement fix, reply with commit SHA |
+| **B: Tech Debt** | Valid but scope creep | Create follow-up issue, reply with issue link |
+| **C: Larger Issue** | Reveals systemic problem | Discuss before proceeding |
+| **D: Disagree** | Misunderstanding or opinion | Reply respectfully explaining position |
+
+## Creating Follow-up Issues
+
+For scope creep items, create an issue and link it:
+
+```bash
+gh issue create --repo SouthwestCCDC/vyos-onecontext \
+  --title "{description}" \
+  --body "Follow-up from PR #{N} review.
+
+{details}
+
+Original comment: https://github.com/SouthwestCCDC/vyos-onecontext/pull/{N}#discussion_r{comment_id}
+
+(AI-generated via Claude Code w/ {Model})"
+```
+
+Then reply to the original comment with the issue link.

--- a/.ai/context/pr-comment-handling.md
+++ b/.ai/context/pr-comment-handling.md
@@ -1,5 +1,19 @@
 # PR Comment Handling
 
+## Prerequisites
+
+These instructions use the [GitHub CLI (`gh`)](https://cli.github.com/). Install and authenticate:
+
+```bash
+# Install (macOS)
+brew install gh
+
+# Authenticate
+gh auth login
+```
+
+**Without `gh` CLI**: Use the GitHub web UI instead. Navigate to the PR's "Files changed" tab to view and reply to comments, or the "Conversation" tab to create issues.
+
 ## Proactive Check After Push
 
 After pushing changes to a PR, check for review comments:
@@ -28,7 +42,7 @@ Every addressed comment needs an inline reply with AI disclosure:
 gh api repos/SouthwestCCDC/vyos-onecontext/pulls/{N}/comments/{comment_id}/replies \
   -f body="Fixed in {SHA}. {brief explanation}
 
-(AI-generated via {Tool} w/ {Model})"
+(AI-generated via {AI Tool} w/ {Model})"
 ```
 
 ## Comment Categories
@@ -55,7 +69,7 @@ gh issue create --repo SouthwestCCDC/vyos-onecontext \
 
 Original comment: https://github.com/SouthwestCCDC/vyos-onecontext/pull/{N}#discussion_r{comment_id}
 
-(AI-generated via {Tool} w/ {Model})"
+(AI-generated via {AI Tool} w/ {Model})"
 ```
 
 Then reply to the original comment with the issue link.

--- a/.ai/context/pr-comment-handling.md
+++ b/.ai/context/pr-comment-handling.md
@@ -28,7 +28,7 @@ Every addressed comment needs an inline reply with AI disclosure:
 gh api repos/SouthwestCCDC/vyos-onecontext/pulls/{N}/comments/{comment_id}/replies \
   -f body="Fixed in {SHA}. {brief explanation}
 
-(AI-generated via Claude Code w/ {Model})"
+(AI-generated via {Tool} w/ {Model})"
 ```
 
 ## Comment Categories
@@ -55,7 +55,10 @@ gh issue create --repo SouthwestCCDC/vyos-onecontext \
 
 Original comment: https://github.com/SouthwestCCDC/vyos-onecontext/pull/{N}#discussion_r{comment_id}
 
-(AI-generated via Claude Code w/ {Model})"
+(AI-generated via {Tool} w/ {Model})"
 ```
 
 Then reply to the original comment with the issue link.
+
+---
+*Generated with Claude Code assistance.*

--- a/.ai/context/quality-commands.md
+++ b/.ai/context/quality-commands.md
@@ -1,0 +1,45 @@
+# Quality Commands
+
+Quality checks use `uv run` and `just` for consistent Python environment.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `just check` | Run all quality checks (pytest + ruff + mypy) |
+| `uv run pytest tests/ -v --tb=short` | Run tests |
+| `uv run ruff check src/ tests/` | Lint Python code |
+| `uv run ruff format src/ tests/` | Format Python code |
+| `uv run mypy src/` | Type checking |
+
+## Pre-Push Checklist
+
+Before pushing any changes:
+
+```bash
+just check
+```
+
+This runs pytest, ruff check, ruff format, and mypy. All must pass before creating or updating a PR.
+
+## Individual Commands
+
+```bash
+# Tests only
+uv run pytest tests/ -v --tb=short
+
+# Linting only
+uv run ruff check src/ tests/
+uv run ruff format src/ tests/
+
+# Type checking only
+uv run mypy src/
+```
+
+## CI Verification
+
+After pushing, verify CI passes:
+
+```bash
+gh pr checks {N} --repo SouthwestCCDC/vyos-onecontext
+```

--- a/.ai/context/quality-commands.md
+++ b/.ai/context/quality-commands.md
@@ -6,7 +6,7 @@ Quality checks use `uv run` and `just` for consistent Python environment.
 
 | Command | Purpose |
 |---------|---------|
-| `just check` | Run all quality checks (pytest + ruff + mypy) |
+| `just check` | Run all quality checks (ruff check + mypy + pytest) |
 | `uv run pytest tests/ -v --tb=short` | Run tests |
 | `uv run ruff check src/ tests/` | Lint Python code |
 | `uv run ruff format src/ tests/` | Format Python code |
@@ -20,7 +20,7 @@ Before pushing any changes:
 just check
 ```
 
-This runs pytest, ruff check, ruff format, and mypy. All must pass before creating or updating a PR.
+This runs ruff check, mypy, and pytest. All must pass before creating or updating a PR.
 
 ## Individual Commands
 
@@ -43,3 +43,6 @@ After pushing, verify CI passes:
 ```bash
 gh pr checks {N} --repo SouthwestCCDC/vyos-onecontext
 ```
+
+---
+*Generated with Claude Code assistance.*

--- a/.ai/context/review-checklist.md
+++ b/.ai/context/review-checklist.md
@@ -1,0 +1,42 @@
+# Review Checklist
+
+Use this checklist when reviewing PRs or pre-commit changes.
+
+## Code Quality
+
+- [ ] Clear, readable code with meaningful names
+- [ ] Appropriate error handling and edge cases
+- [ ] Follows existing patterns in the codebase
+- [ ] Type hints present on public functions
+
+## VyOS Specific
+
+- [ ] Correct VyOS Sagitta syntax (NOT Equuleus)
+- [ ] Commands tested against actual VyOS Sagitta
+- [ ] No deprecated VyOS features used
+- [ ] Configuration paths match VyOS hierarchy
+
+## Testing
+
+- [ ] Tests cover new functionality
+- [ ] Edge cases handled (missing fields, malformed input)
+- [ ] Pytest tests pass: `uv run pytest tests/ -v`
+
+## Security
+
+- [ ] No hardcoded credentials or secrets
+- [ ] Input validation present
+- [ ] Context variables sanitized
+
+## AI Disclosure
+
+- [ ] Commits have `Co-Authored-By: Claude {Model} <noreply@anthropic.com>`
+- [ ] PR description mentions AI assistance if applicable
+
+## Assessment Categories
+
+| Assessment | Meaning |
+|------------|---------|
+| **Ready to merge** | All checks pass, no blocking issues |
+| **Needs fixes** | Issues found that must be addressed |
+| **Needs discussion** | Architectural or scope questions to resolve |

--- a/.ai/context/review-checklist.md
+++ b/.ai/context/review-checklist.md
@@ -30,7 +30,7 @@ Use this checklist when reviewing PRs or pre-commit changes.
 
 ## AI Disclosure
 
-- [ ] Commits have `Co-Authored-By: Claude {Model} <noreply@anthropic.com>`
+- [ ] Commits have `Co-authored-by: Claude {Model} <noreply@anthropic.com>`
 - [ ] PR description mentions AI assistance if applicable
 
 ## Assessment Categories
@@ -40,3 +40,6 @@ Use this checklist when reviewing PRs or pre-commit changes.
 | **Ready to merge** | All checks pass, no blocking issues |
 | **Needs fixes** | Issues found that must be addressed |
 | **Needs discussion** | Architectural or scope questions to resolve |
+
+---
+*Generated with Claude Code assistance.*

--- a/.ai/context/review-checklist.md
+++ b/.ai/context/review-checklist.md
@@ -30,7 +30,7 @@ Use this checklist when reviewing PRs or pre-commit changes.
 
 ## AI Disclosure
 
-- [ ] Commits have `Co-authored-by: Claude {Model} <noreply@anthropic.com>`
+- [ ] AI-generated commits have `Co-authored-by:` line (see `commit-conventions.md`)
 - [ ] PR description mentions AI assistance if applicable
 
 ## Assessment Categories

--- a/.ai/context/worktree-workflow.md
+++ b/.ai/context/worktree-workflow.md
@@ -42,3 +42,6 @@ The timestamp ensures uniqueness when revisiting the same issue.
 2. **Work** entirely within the worktree
 3. **Push** branch and create PR
 4. **Delete** after PR is merged: `git worktree remove {path}`
+
+---
+*Generated with Claude Code assistance.*

--- a/.ai/context/worktree-workflow.md
+++ b/.ai/context/worktree-workflow.md
@@ -1,0 +1,44 @@
+# Worktree Workflow
+
+All implementation work happens in isolated git worktrees, never in the main repository checkout.
+
+## Why Worktrees
+
+- Isolates work-in-progress from the main checkout
+- Enables parallel work on multiple issues
+- Prevents accidental commits to protected branches
+- Clean state for each task
+
+## Rules
+
+1. **Never modify the main repo** - It's read-only for reference
+2. **One worktree per task** - Named for the issue/feature
+3. **Clean up when done** - Remove worktrees after PR merge
+
+## Creating a Worktree
+
+```bash
+# From main repo directory
+git fetch origin
+git worktree add ../vyos-onecontext-worktrees/issue-{N}-$(date +%s) \
+  -b issue-{N}-$(date +%s) origin/sagitta
+
+# Navigate to worktree
+cd ../vyos-onecontext-worktrees/issue-{N}-*
+```
+
+**Note**: The default branch is `sagitta`, not `main` or `default`.
+
+## Naming Convention
+
+- Issue work: `issue-{N}-{timestamp}`
+- Feature work: `feat-{description}-{timestamp}`
+
+The timestamp ensures uniqueness when revisiting the same issue.
+
+## Worktree Lifecycle
+
+1. **Create** when starting a task
+2. **Work** entirely within the worktree
+3. **Push** branch and create PR
+4. **Delete** after PR is merged: `git worktree remove {path}`

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -33,7 +33,7 @@ Also read `../copilot-instructions.md` for VyOS Sagitta syntax and project conve
 
 1. **Understand**: Read the issue/PR and relevant existing code
 2. **Implement**: Make incremental changes, commit frequently
-3. **Test**: Run `just check` (pytest + ruff + mypy)
+3. **Test**: Run `just check` (ruff + mypy + pytest)
 4. **Push**: Create PR or push to existing branch
 5. **Respond**: Address any review comments
 

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -22,7 +22,7 @@ Before starting, read these guidelines:
 - [Commit Conventions](../../.ai/context/commit-conventions.md) - Message format and AI disclosure
 - [PR Comment Handling](../../.ai/context/pr-comment-handling.md) - Responding to review feedback
 
-Also read `.github/copilot-instructions.md` for VyOS Sagitta syntax and project conventions.
+Also read `../copilot-instructions.md` for VyOS Sagitta syntax and project conventions.
 
 ## Key References
 
@@ -46,3 +46,6 @@ Also read `.github/copilot-instructions.md` for VyOS Sagitta syntax and project 
 ## Output
 
 End with a summary of what was accomplished, PR number/URL, CI status, and any follow-up needed.
+
+---
+*Generated with Claude Code assistance.*

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -1,0 +1,48 @@
+---
+name: VyOS Script Developer
+description: Implements features and fixes bugs for VyOS OneContext scripts
+tools: ['githubRepo', 'search', 'editFiles', 'runTerminalLastCommand', 'fetch']
+handoffs:
+  - label: "Request Review"
+    agent: reviewer
+    prompt: "Review the changes I just made before I push"
+    send: false
+---
+
+# VyOS Script Developer
+
+You implement features, fix bugs, and address PR comments for vyos-onecontext.
+
+## Context
+
+Before starting, read these guidelines:
+
+- [Worktree Workflow](../../.ai/context/worktree-workflow.md) - Work in isolated worktrees
+- [Quality Commands](../../.ai/context/quality-commands.md) - Testing with just and uv
+- [Commit Conventions](../../.ai/context/commit-conventions.md) - Message format and AI disclosure
+- [PR Comment Handling](../../.ai/context/pr-comment-handling.md) - Responding to review feedback
+
+Also read `.github/copilot-instructions.md` for VyOS Sagitta syntax and project conventions.
+
+## Key References
+
+- `docs/design.md` - Architecture decisions
+- `docs/context-reference.md` - JSON schemas for context variables
+
+## Workflow
+
+1. **Understand**: Read the issue/PR and relevant existing code
+2. **Implement**: Make incremental changes, commit frequently
+3. **Test**: Run `just check` (pytest + ruff + mypy)
+4. **Push**: Create PR or push to existing branch
+5. **Respond**: Address any review comments
+
+## VyOS Notes
+
+- Target **Sagitta** syntax, NOT Equuleus
+- Test generated commands against actual VyOS if possible
+- Follow existing generator patterns in `src/`
+
+## Output
+
+End with a summary of what was accomplished, PR number/URL, CI status, and any follow-up needed.

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,0 +1,65 @@
+---
+name: VyOS PR Reviewer
+description: Reviews PRs and triages review comments for vyos-onecontext
+tools: ['githubRepo', 'search', 'fetch']
+handoffs:
+  - label: "Fix Issues"
+    agent: developer
+    prompt: "Fix the issues I identified in my review"
+    send: false
+---
+
+# VyOS PR Reviewer
+
+You review PRs and triage review comments. Two modes: **Review** (proactive) and **Response** (reactive).
+
+## Context
+
+Before reviewing, read these guidelines:
+
+- [Review Checklist](../../.ai/context/review-checklist.md) - What to check
+- [PR Comment Handling](../../.ai/context/pr-comment-handling.md) - Comment categories and responses
+
+Also read `.github/copilot-instructions.md` for VyOS Sagitta syntax rules.
+
+## Mode 1: PR Review
+
+Review a PR with critical eyes before merge.
+
+```bash
+gh pr view {N} --json title,body,files
+gh pr diff {N}
+```
+
+### Special Attention
+
+- Correct VyOS Sagitta syntax (not Equuleus)
+- Proper error handling for missing context fields
+- Test coverage for new functionality
+
+### Output Format
+
+```markdown
+## PR Review: #{N} - {title}
+
+**Assessment**: Ready / Needs fixes / Needs discussion
+
+### Issues Found
+**Critical** (must fix):
+- file.py:42 - description
+
+**Important** (should fix):
+- file.py:87 - description
+
+**Minor** (suggestions):
+- file.py:12 - description
+
+### Recommendation
+Approve / Request changes / Needs discussion
+```
+
+## Mode 2: Review Response
+
+Analyze incoming comments and categorize them as A (Fix), B (Tech Debt), C (Larger Issue), or D (Disagree).
+
+Include `comment_id` in output so developer agents can reply inline.

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -20,7 +20,7 @@ Before reviewing, read these guidelines:
 - [Review Checklist](../../.ai/context/review-checklist.md) - What to check
 - [PR Comment Handling](../../.ai/context/pr-comment-handling.md) - Comment categories and responses
 
-Also read `.github/copilot-instructions.md` for VyOS Sagitta syntax rules.
+Also read `../copilot-instructions.md` for VyOS Sagitta syntax rules.
 
 ## Mode 1: PR Review
 
@@ -63,3 +63,6 @@ Approve / Request changes / Needs discussion
 Analyze incoming comments and categorize them as A (Fix), B (Tech Debt), C (Larger Issue), or D (Disagree).
 
 Include `comment_id` in output so developer agents can reply inline.
+
+---
+*Generated with Claude Code assistance.*


### PR DESCRIPTION
## Summary

- Adds `.ai/context/` directory with shared knowledge files that both Claude Code and Copilot agents can reference
- Creates Copilot agents in `.github/agents/` with handoffs between them
- Reduces drift between AI assistant configurations by using a single source of truth

### Context Files Added

| File | Purpose |
|------|---------|
| `worktree-workflow.md` | Git worktree isolation rules |
| `quality-commands.md` | just/uv/pytest workflow |
| `commit-conventions.md` | Message format and AI disclosure |
| `pr-comment-handling.md` | Review response protocol |
| `review-checklist.md` | PR review criteria (VyOS Sagitta focus) |

### Copilot Agents Added

- `developer.agent.md` - Feature implementation
- `reviewer.agent.md` - PR review and comment triage

## Test plan

- [ ] Verify Copilot agents are discoverable in VS Code
- [ ] Verify context file links resolve correctly

🤖 Generated with [Claude Code](https://claude.ai/code)