### PR TITLE
Remove duplicate dev dependencies from optional-dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --group dev
 
       - name: Run checks
         run: just check
@@ -62,7 +62,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-x86 genisoimage packer sshpass
           # Install Python dependencies for pytest integration tests
-          uv sync --extra dev
+          uv sync --group dev
 
       - name: Download base VyOS image
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,6 @@ dependencies = [
     "pydantic>=2.0",
 ]
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=8.0",
-    "ruff>=0.1",
-    "mypy>=1.8",
-]
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/uv.lock
+++ b/uv.lock
@@ -359,13 +359,6 @@ dependencies = [
     { name = "pydantic" },
 ]
 
-[package.optional-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "ruff" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
@@ -374,13 +367,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
-    { name = "pydantic", specifier = ">=2.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
-]
-provides-extras = ["dev"]
+requires-dist = [{ name = "pydantic", specifier = ">=2.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Remove `[project.optional-dependencies]` section that duplicated dev dependencies
- Keep only the modern `[dependency-groups]` section (PEP 735)
- Update CI workflow to use `--group dev` instead of `--extra dev`
- Update uv.lock to reflect dependency changes
- Affected packages: pytest, ruff, mypy

## Rationale
The repository had duplicate dev dependency declarations:
- `[project.optional-dependencies].dev` with older version constraints
- `[dependency-groups].dev` with current version constraints

PEP 735 dependency-groups is the recommended modern approach for Python dependency management, and having both sections creates maintenance burden and potential version conflicts.

## Changes Made
1. **pyproject.toml**: Removed `[project.optional-dependencies]` section
2. **ci.yml**: Changed `uv sync --extra dev` to `uv sync --group dev` (2 locations)
3. **uv.lock**: Updated lockfile to reflect dependency changes

## Test Plan
- [x] Verify all quality checks pass with `just check`
- [x] Confirm CI passes after removing optional-dependencies and updating workflow

Closes #152

Generated with Claude Code w/ Sonnet 4.5