### PR TITLE
feat(nat): Add address-mapping and conntrack timeout support for IP hopping

### DIFF
--- a/src/vyos_onecontext/generators/__init__.py
+++ b/src/vyos_onecontext/generators/__init__.py
@@ -14,7 +14,7 @@ from vyos_onecontext.generators.nat import NatGenerator
 from vyos_onecontext.generators.ospf import OspfGenerator
 from vyos_onecontext.generators.routing import RoutingGenerator, StaticRoutesGenerator
 from vyos_onecontext.generators.service import SshServiceGenerator
-from vyos_onecontext.generators.system import HostnameGenerator, SshKeyGenerator
+from vyos_onecontext.generators.system import ConntrackGenerator, HostnameGenerator, SshKeyGenerator
 from vyos_onecontext.generators.vrf import VRF_NAME, VRF_TABLE_ID, VrfGenerator
 from vyos_onecontext.models import RouterConfig
 
@@ -68,6 +68,9 @@ def generate_config(config: RouterConfig) -> list[str]:
     # Firewall (groups, zones, global state policy, inter-zone policies)
     commands.extend(FirewallGenerator(config.firewall).generate())
 
+    # Conntrack timeout rules
+    commands.extend(ConntrackGenerator(config.conntrack).generate())
+
     # Custom config (START_CONFIG) - executed last, before commit
     commands.extend(StartConfigGenerator(config.start_config).generate())
 
@@ -79,6 +82,7 @@ def generate_config(config: RouterConfig) -> list[str]:
 
 __all__ = [
     "BaseGenerator",
+    "ConntrackGenerator",
     "DhcpGenerator",
     "FirewallGenerator",
     "HostnameGenerator",

--- a/src/vyos_onecontext/generators/nat.py
+++ b/src/vyos_onecontext/generators/nat.py
@@ -98,6 +98,13 @@ class NatGenerator(BaseGenerator):
                     f"set nat source rule {rule_num} translation address {rule.translation_address}"
                 )
 
+            # Address mapping option (for IP pools)
+            if rule.address_mapping:
+                commands.append(
+                    f"set nat source rule {rule_num} translation options "
+                    f"address-mapping {rule.address_mapping}"
+                )
+
             # Description (optional)
             if rule.description:
                 commands.append(f"set nat source rule {rule_num} description '{rule.description}'")

--- a/src/vyos_onecontext/models/__init__.py
+++ b/src/vyos_onecontext/models/__init__.py
@@ -27,6 +27,7 @@ from vyos_onecontext.models.routing import (
     RoutesConfig,
     StaticRoute,
 )
+from vyos_onecontext.models.system import ConntrackConfig, ConntrackTimeoutRule
 
 __all__ = [
     # config
@@ -56,4 +57,7 @@ __all__ = [
     "OspfInterface",
     "RoutesConfig",
     "StaticRoute",
+    # system
+    "ConntrackConfig",
+    "ConntrackTimeoutRule",
 ]

--- a/src/vyos_onecontext/models/config.py
+++ b/src/vyos_onecontext/models/config.py
@@ -11,6 +11,7 @@ from vyos_onecontext.models.firewall import FirewallConfig
 from vyos_onecontext.models.interface import AliasConfig, InterfaceConfig
 from vyos_onecontext.models.nat import NatConfig
 from vyos_onecontext.models.routing import OspfConfig, RoutesConfig
+from vyos_onecontext.models.system import ConntrackConfig
 
 
 class OnecontextMode(str, Enum):
@@ -154,6 +155,11 @@ class RouterConfig(BaseModel):
     # Firewall
     firewall: Annotated[
         FirewallConfig | None, Field(None, description="Zone-based firewall configuration")
+    ]
+
+    # System
+    conntrack: Annotated[
+        ConntrackConfig | None, Field(None, description="Conntrack timeout configuration")
     ]
 
     # Escape hatches

--- a/src/vyos_onecontext/models/nat.py
+++ b/src/vyos_onecontext/models/nat.py
@@ -23,6 +23,10 @@ class SourceNatRule(BaseModel):
     translation_address: Annotated[
         str | None, Field(None, description="Static SNAT address or range")
     ]
+    address_mapping: Annotated[
+        Literal["random", "persistent"] | None,
+        Field(None, description="Address mapping mode for translation address pools"),
+    ]
     description: Annotated[str | None, Field(None, description="Rule description")]
 
     @field_validator("source_address")

--- a/src/vyos_onecontext/models/nat.py
+++ b/src/vyos_onecontext/models/nat.py
@@ -88,6 +88,13 @@ class SourceNatRule(BaseModel):
             raise ValueError("Cannot specify both 'translation' and 'translation_address'")
         if not has_translation and not has_address:
             raise ValueError("Must specify either 'translation' or 'translation_address'")
+        
+        # Validate address_mapping only used with translation_address
+        if self.address_mapping is not None and has_translation:
+            raise ValueError(
+                "address_mapping can only be used with translation_address (pools), "
+                "not with translation='masquerade'"
+            )
         return self
 
 

--- a/src/vyos_onecontext/models/nat.py
+++ b/src/vyos_onecontext/models/nat.py
@@ -88,7 +88,7 @@ class SourceNatRule(BaseModel):
             raise ValueError("Cannot specify both 'translation' and 'translation_address'")
         if not has_translation and not has_address:
             raise ValueError("Must specify either 'translation' or 'translation_address'")
-        
+
         # Validate address_mapping only used with translation_address
         if self.address_mapping is not None and has_translation:
             raise ValueError(

--- a/src/vyos_onecontext/models/system.py
+++ b/src/vyos_onecontext/models/system.py
@@ -1,0 +1,115 @@
+"""System configuration models (conntrack, etc.)."""
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class ConntrackTimeoutRule(BaseModel):
+    """Conntrack timeout custom rule for connection tracking timeout configuration.
+
+    Allows customization of connection tracking timeouts for specific traffic patterns.
+    Useful for IP hopping scenarios where short idle timeouts force connection remapping.
+    """
+
+    description: Annotated[
+        str | None, Field(None, description="Rule description")
+    ]
+    source_address: Annotated[
+        str | None, Field(None, description="Source CIDR to match")
+    ]
+    destination_address: Annotated[
+        str | None, Field(None, description="Destination CIDR to match")
+    ]
+    protocol: Annotated[
+        Literal["tcp", "udp", "icmp"], Field(description="Protocol to match")
+    ]
+    # TCP-specific timeout options
+    tcp_close: Annotated[
+        int | None, Field(None, ge=1, description="TCP close timeout (seconds)")
+    ]
+    tcp_close_wait: Annotated[
+        int | None, Field(None, ge=1, description="TCP close-wait timeout (seconds)")
+    ]
+    tcp_established: Annotated[
+        int | None, Field(None, ge=1, description="TCP established timeout (seconds)")
+    ]
+    tcp_fin_wait: Annotated[
+        int | None, Field(None, ge=1, description="TCP fin-wait timeout (seconds)")
+    ]
+    tcp_last_ack: Annotated[
+        int | None, Field(None, ge=1, description="TCP last-ack timeout (seconds)")
+    ]
+    tcp_syn_recv: Annotated[
+        int | None, Field(None, ge=1, description="TCP syn-recv timeout (seconds)")
+    ]
+    tcp_syn_sent: Annotated[
+        int | None, Field(None, ge=1, description="TCP syn-sent timeout (seconds)")
+    ]
+    tcp_time_wait: Annotated[
+        int | None, Field(None, ge=1, description="TCP time-wait timeout (seconds)")
+    ]
+    # UDP-specific timeout options
+    udp_other: Annotated[
+        int | None, Field(None, ge=1, description="UDP other timeout (seconds)")
+    ]
+    udp_stream: Annotated[
+        int | None, Field(None, ge=1, description="UDP stream timeout (seconds)")
+    ]
+    # ICMP-specific timeout option
+    icmp_timeout: Annotated[
+        int | None, Field(None, ge=1, description="ICMP timeout (seconds)")
+    ]
+
+    @model_validator(mode="after")
+    def validate_protocol_specific_timeouts(self) -> "ConntrackTimeoutRule":
+        """Ensure protocol-specific timeout fields match the protocol."""
+        tcp_fields = {
+            "tcp_close", "tcp_close_wait", "tcp_established", "tcp_fin_wait",
+            "tcp_last_ack", "tcp_syn_recv", "tcp_syn_sent", "tcp_time_wait"
+        }
+        udp_fields = {"udp_other", "udp_stream"}
+        icmp_fields = {"icmp_timeout"}
+
+        # Check for protocol mismatches
+        if self.protocol == "tcp":
+            for field in udp_fields | icmp_fields:
+                if getattr(self, field) is not None:
+                    raise ValueError(
+                        f"Field '{field}' is not valid for protocol 'tcp'"
+                    )
+        elif self.protocol == "udp":
+            for field in tcp_fields | icmp_fields:
+                if getattr(self, field) is not None:
+                    raise ValueError(
+                        f"Field '{field}' is not valid for protocol 'udp'"
+                    )
+        elif self.protocol == "icmp":
+            for field in tcp_fields | udp_fields:
+                if getattr(self, field) is not None:
+                    raise ValueError(
+                        f"Field '{field}' is not valid for protocol 'icmp'"
+                    )
+
+        # Ensure at least one timeout field is set for the protocol
+        if self.protocol == "tcp":
+            if not any(getattr(self, field) is not None for field in tcp_fields):
+                raise ValueError("At least one TCP timeout field must be set")
+        elif self.protocol == "udp":
+            if not any(getattr(self, field) is not None for field in udp_fields):
+                raise ValueError("At least one UDP timeout field must be set")
+        elif self.protocol == "icmp" and self.icmp_timeout is None:
+            raise ValueError("ICMP timeout field must be set for ICMP protocol")
+
+        return self
+
+
+class ConntrackConfig(BaseModel):
+    """Conntrack configuration.
+
+    Contains custom timeout rules for connection tracking.
+    """
+
+    timeout_rules: list[ConntrackTimeoutRule] = Field(
+        default_factory=list, description="Custom timeout rules"
+    )

--- a/src/vyos_onecontext/models/system.py
+++ b/src/vyos_onecontext/models/system.py
@@ -99,7 +99,7 @@ class ConntrackTimeoutRule(BaseModel):
             if not any(getattr(self, field) is not None for field in udp_fields):
                 raise ValueError("At least one UDP timeout field must be set")
         elif self.protocol == "icmp" and self.icmp_timeout is None:
-            raise ValueError("ICMP timeout field must be set for ICMP protocol")
+            raise ValueError("ICMP timeout field must be set")
 
         return self
 

--- a/src/vyos_onecontext/parser.py
+++ b/src/vyos_onecontext/parser.py
@@ -18,6 +18,7 @@ from vyos_onecontext.models.firewall import FirewallConfig
 from vyos_onecontext.models.interface import AliasConfig, InterfaceConfig
 from vyos_onecontext.models.nat import NatConfig
 from vyos_onecontext.models.routing import OspfConfig, RoutesConfig
+from vyos_onecontext.models.system import ConntrackConfig
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -64,6 +65,7 @@ class ContextParser:
         dhcp = self._parse_dhcp()
         nat = self._parse_nat()
         firewall = self._parse_firewall()
+        conntrack = self._parse_conntrack()
 
         # Parse operational variables
         hostname = self.variables.get("HOSTNAME")
@@ -87,6 +89,7 @@ class ContextParser:
             dhcp=dhcp,
             nat=nat,
             firewall=firewall,
+            conntrack=conntrack,
             start_config=start_config,
             start_script=start_script,
             start_script_timeout=start_script_timeout,
@@ -462,6 +465,14 @@ class ContextParser:
             FirewallConfig or None if not present
         """
         return self._parse_json_variable("FIREWALL_JSON", FirewallConfig)
+
+    def _parse_conntrack(self) -> ConntrackConfig | None:
+        """Parse CONNTRACK_JSON variable.
+
+        Returns:
+            ConntrackConfig or None if not present
+        """
+        return self._parse_json_variable("CONNTRACK_JSON", ConntrackConfig)
 
 
 def parse_context(

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -5,6 +5,7 @@ from ipaddress import IPv4Address
 from vyos_onecontext.generators import (
     VRF_NAME,
     VRF_TABLE_ID,
+    ConntrackGenerator,
     FirewallGenerator,
     HostnameGenerator,
     InterfaceGenerator,
@@ -20,6 +21,8 @@ from vyos_onecontext.generators import (
 from vyos_onecontext.models import (
     AliasConfig,
     BinatRule,
+    ConntrackConfig,
+    ConntrackTimeoutRule,
     DestinationNatRule,
     FirewallConfig,
     FirewallGroups,
@@ -3571,3 +3574,233 @@ set system time-zone America/Chicago"""
         commands = gen.generate()
 
         assert len(commands) == 0
+
+
+# === Conntrack Generator Tests ===
+
+
+class TestConntrackGenerator:
+    """Tests for ConntrackGenerator."""
+
+    def test_none_conntrack(self):
+        """Test generator with no conntrack configuration."""
+        gen = ConntrackGenerator(None)
+        commands = gen.generate()
+        assert commands == []
+
+    def test_empty_config(self):
+        """Test generator with empty conntrack configuration."""
+        config = ConntrackConfig(timeout_rules=[])
+        gen = ConntrackGenerator(config)
+        commands = gen.generate()
+        assert commands == []
+
+    def test_single_tcp_rule(self):
+        """Test single TCP conntrack timeout rule."""
+        config = ConntrackConfig(
+            timeout_rules=[
+                ConntrackTimeoutRule(
+                    description="IP hopping - short idle timeout",
+                    source_address="10.60.0.0/14",
+                    protocol="tcp",
+                    tcp_established=60,
+                )
+            ]
+        )
+        gen = ConntrackGenerator(config)
+        commands = gen.generate()
+
+        expected = [
+            "set system conntrack timeout custom rule 1 "
+            "description 'IP hopping - short idle timeout'",
+            "set system conntrack timeout custom rule 1 source address 10.60.0.0/14",
+            "set system conntrack timeout custom rule 1 protocol tcp",
+            "set system conntrack timeout custom rule 1 protocol tcp established 60",
+        ]
+        assert commands == expected
+
+    def test_multiple_tcp_timeouts(self):
+        """Test TCP rule with multiple timeout values."""
+        config = ConntrackConfig(
+            timeout_rules=[
+                ConntrackTimeoutRule(
+                    protocol="tcp",
+                    tcp_established=60,
+                    tcp_time_wait=30,
+                    tcp_syn_sent=10,
+                )
+            ]
+        )
+        gen = ConntrackGenerator(config)
+        commands = gen.generate()
+
+        assert "set system conntrack timeout custom rule 1 protocol tcp" in commands
+        assert "set system conntrack timeout custom rule 1 protocol tcp established 60" in commands
+        assert "set system conntrack timeout custom rule 1 protocol tcp time-wait 30" in commands
+        assert "set system conntrack timeout custom rule 1 protocol tcp syn-sent 10" in commands
+
+    def test_udp_rule(self):
+        """Test UDP conntrack timeout rule."""
+        config = ConntrackConfig(
+            timeout_rules=[
+                ConntrackTimeoutRule(
+                    protocol="udp",
+                    udp_stream=30,
+                    udp_other=10,
+                )
+            ]
+        )
+        gen = ConntrackGenerator(config)
+        commands = gen.generate()
+
+        assert "set system conntrack timeout custom rule 1 protocol udp" in commands
+        assert "set system conntrack timeout custom rule 1 protocol udp stream 30" in commands
+        assert "set system conntrack timeout custom rule 1 protocol udp other 10" in commands
+
+    def test_icmp_rule(self):
+        """Test ICMP conntrack timeout rule."""
+        config = ConntrackConfig(
+            timeout_rules=[
+                ConntrackTimeoutRule(
+                    protocol="icmp",
+                    icmp_timeout=5,
+                )
+            ]
+        )
+        gen = ConntrackGenerator(config)
+        commands = gen.generate()
+
+        assert "set system conntrack timeout custom rule 1 protocol icmp" in commands
+        assert "set system conntrack timeout custom rule 1 icmp 5" in commands
+
+    def test_multiple_rules(self):
+        """Test multiple conntrack timeout rules."""
+        config = ConntrackConfig(
+            timeout_rules=[
+                ConntrackTimeoutRule(
+                    description="TCP timeout",
+                    protocol="tcp",
+                    tcp_established=60,
+                ),
+                ConntrackTimeoutRule(
+                    description="UDP timeout",
+                    protocol="udp",
+                    udp_stream=30,
+                ),
+            ]
+        )
+        gen = ConntrackGenerator(config)
+        commands = gen.generate()
+
+        # Check rule 1 (TCP)
+        assert "set system conntrack timeout custom rule 1 description 'TCP timeout'" in commands
+        assert "set system conntrack timeout custom rule 1 protocol tcp" in commands
+        assert "set system conntrack timeout custom rule 1 protocol tcp established 60" in commands
+
+        # Check rule 2 (UDP)
+        assert "set system conntrack timeout custom rule 2 description 'UDP timeout'" in commands
+        assert "set system conntrack timeout custom rule 2 protocol udp" in commands
+        assert "set system conntrack timeout custom rule 2 protocol udp stream 30" in commands
+
+    def test_rule_with_destination_address(self):
+        """Test rule with both source and destination addresses."""
+        config = ConntrackConfig(
+            timeout_rules=[
+                ConntrackTimeoutRule(
+                    source_address="10.60.0.0/14",
+                    destination_address="203.0.113.0/24",
+                    protocol="tcp",
+                    tcp_established=120,
+                )
+            ]
+        )
+        gen = ConntrackGenerator(config)
+        commands = gen.generate()
+
+        assert "set system conntrack timeout custom rule 1 source address 10.60.0.0/14" in commands
+        assert (
+            "set system conntrack timeout custom rule 1 destination address 203.0.113.0/24"
+            in commands
+        )
+
+
+# === NAT Generator Address Mapping Tests ===
+
+
+class TestNatGeneratorAddressMapping:
+    """Tests for address-mapping option in NAT generator."""
+
+    def test_address_mapping_random(self):
+        """Test NAT rule generation with random address mapping."""
+        config = NatConfig(
+            source=[
+                SourceNatRule(
+                    outbound_interface="eth2",
+                    source_address="10.60.0.0/14",
+                    translation_address="10.97.0.0-10.103.255.254",
+                    address_mapping="random",
+                )
+            ]
+        )
+        gen = NatGenerator(config)
+        commands = gen.generate()
+
+        assert "set nat source rule 100 outbound-interface name eth2" in commands
+        assert "set nat source rule 100 source address 10.60.0.0/14" in commands
+        assert "set nat source rule 100 translation address 10.97.0.0-10.103.255.254" in commands
+        assert "set nat source rule 100 translation options address-mapping random" in commands
+
+    def test_address_mapping_persistent(self):
+        """Test NAT rule generation with persistent address mapping."""
+        config = NatConfig(
+            source=[
+                SourceNatRule(
+                    outbound_interface="eth2",
+                    source_address="10.60.0.0/14",
+                    translation_address="10.97.0.0-10.103.255.254",
+                    address_mapping="persistent",
+                )
+            ]
+        )
+        gen = NatGenerator(config)
+        commands = gen.generate()
+
+        assert "set nat source rule 100 translation options address-mapping persistent" in commands
+
+    def test_no_address_mapping(self):
+        """Test NAT rule generation without address mapping (default behavior)."""
+        config = NatConfig(
+            source=[
+                SourceNatRule(
+                    outbound_interface="eth2",
+                    source_address="10.60.0.0/14",
+                    translation_address="10.97.0.0-10.103.255.254",
+                )
+            ]
+        )
+        gen = NatGenerator(config)
+        commands = gen.generate()
+
+        # Should not include address-mapping option
+        assert not any("address-mapping" in cmd for cmd in commands)
+        # But should still have translation address
+        assert "set nat source rule 100 translation address 10.97.0.0-10.103.255.254" in commands
+
+    def test_address_mapping_with_description(self):
+        """Test NAT rule with both address mapping and description."""
+        config = NatConfig(
+            source=[
+                SourceNatRule(
+                    outbound_interface="eth2",
+                    source_address="10.60.0.0/14",
+                    translation_address="10.97.0.0-10.103.255.254",
+                    address_mapping="random",
+                    description="IP hopping for scoring traffic",
+                )
+            ]
+        )
+        gen = NatGenerator(config)
+        commands = gen.generate()
+
+        assert "set nat source rule 100 translation options address-mapping random" in commands
+        assert "set nat source rule 100 description 'IP hopping for scoring traffic'" in commands

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -3610,6 +3610,7 @@ class TestConntrackGenerator:
         gen = ConntrackGenerator(config)
         commands = gen.generate()
 
+        # Note: First string uses implicit concatenation for readability
         expected = [
             "set system conntrack timeout custom rule 1 "
             "description 'IP hopping - short idle timeout'",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1273,7 +1273,7 @@ class TestInputValidation:
 class TestConntrackTimeoutRule:
     """Tests for ConntrackTimeoutRule model."""
 
-    def test_tcp_rule_valid(self):
+    def test_tcp_rule_valid(self) -> None:
         """Test valid TCP conntrack timeout rule."""
         rule = ConntrackTimeoutRule(
             description="Short timeout for scoring",
@@ -1286,7 +1286,7 @@ class TestConntrackTimeoutRule:
         assert rule.protocol == "tcp"
         assert rule.tcp_established == 60
 
-    def test_udp_rule_valid(self):
+    def test_udp_rule_valid(self) -> None:
         """Test valid UDP conntrack timeout rule."""
         rule = ConntrackTimeoutRule(
             protocol="udp",
@@ -1297,7 +1297,7 @@ class TestConntrackTimeoutRule:
         assert rule.udp_stream == 30
         assert rule.udp_other == 10
 
-    def test_icmp_rule_valid(self):
+    def test_icmp_rule_valid(self) -> None:
         """Test valid ICMP conntrack timeout rule."""
         rule = ConntrackTimeoutRule(
             protocol="icmp",
@@ -1306,7 +1306,7 @@ class TestConntrackTimeoutRule:
         assert rule.protocol == "icmp"
         assert rule.icmp_timeout == 5
 
-    def test_tcp_with_udp_field_invalid(self):
+    def test_tcp_with_udp_field_invalid(self) -> None:
         """Test that TCP rule cannot have UDP fields."""
         with pytest.raises(ValidationError, match="not valid for protocol 'tcp'"):
             ConntrackTimeoutRule(
@@ -1315,7 +1315,7 @@ class TestConntrackTimeoutRule:
                 udp_stream=30,  # Invalid for TCP
             )
 
-    def test_udp_with_tcp_field_invalid(self):
+    def test_udp_with_tcp_field_invalid(self) -> None:
         """Test that UDP rule cannot have TCP fields."""
         with pytest.raises(ValidationError, match="not valid for protocol 'udp'"):
             ConntrackTimeoutRule(
@@ -1324,7 +1324,7 @@ class TestConntrackTimeoutRule:
                 tcp_established=60,  # Invalid for UDP
             )
 
-    def test_icmp_with_tcp_field_invalid(self):
+    def test_icmp_with_tcp_field_invalid(self) -> None:
         """Test that ICMP rule cannot have TCP fields."""
         with pytest.raises(ValidationError, match="not valid for protocol 'icmp'"):
             ConntrackTimeoutRule(
@@ -1333,7 +1333,7 @@ class TestConntrackTimeoutRule:
                 tcp_established=60,  # Invalid for ICMP
             )
 
-    def test_tcp_without_timeout_invalid(self):
+    def test_tcp_without_timeout_invalid(self) -> None:
         """Test that TCP rule requires at least one TCP timeout field."""
         with pytest.raises(ValidationError, match="At least one TCP timeout field must be set"):
             ConntrackTimeoutRule(
@@ -1341,7 +1341,7 @@ class TestConntrackTimeoutRule:
                 source_address="10.0.0.0/8",
             )
 
-    def test_udp_without_timeout_invalid(self):
+    def test_udp_without_timeout_invalid(self) -> None:
         """Test that UDP rule requires at least one UDP timeout field."""
         with pytest.raises(ValidationError, match="At least one UDP timeout field must be set"):
             ConntrackTimeoutRule(
@@ -1349,7 +1349,7 @@ class TestConntrackTimeoutRule:
                 source_address="10.0.0.0/8",
             )
 
-    def test_icmp_without_timeout_invalid(self):
+    def test_icmp_without_timeout_invalid(self) -> None:
         """Test that ICMP rule requires icmp_timeout field."""
         with pytest.raises(ValidationError, match="ICMP timeout field must be set"):
             ConntrackTimeoutRule(
@@ -1357,7 +1357,7 @@ class TestConntrackTimeoutRule:
                 source_address="10.0.0.0/8",
             )
 
-    def test_all_tcp_timeouts(self):
+    def test_all_tcp_timeouts(self) -> None:
         """Test TCP rule with all timeout fields set."""
         rule = ConntrackTimeoutRule(
             protocol="tcp",
@@ -1383,12 +1383,12 @@ class TestConntrackTimeoutRule:
 class TestConntrackConfig:
     """Tests for ConntrackConfig model."""
 
-    def test_empty_config(self):
+    def test_empty_config(self) -> None:
         """Test empty conntrack configuration."""
         config = ConntrackConfig()
         assert config.timeout_rules == []
 
-    def test_single_rule(self):
+    def test_single_rule(self) -> None:
         """Test conntrack config with single rule."""
         config = ConntrackConfig(
             timeout_rules=[
@@ -1403,7 +1403,7 @@ class TestConntrackConfig:
         assert len(config.timeout_rules) == 1
         assert config.timeout_rules[0].description == "IP hopping timeout"
 
-    def test_multiple_rules(self):
+    def test_multiple_rules(self) -> None:
         """Test conntrack config with multiple rules."""
         config = ConntrackConfig(
             timeout_rules=[
@@ -1433,7 +1433,7 @@ class TestConntrackConfig:
 class TestSourceNatRuleAddressMapping:
     """Tests for address_mapping field in SourceNatRule."""
 
-    def test_address_mapping_random(self):
+    def test_address_mapping_random(self) -> None:
         """Test source NAT rule with random address mapping."""
         rule = SourceNatRule(
             outbound_interface="eth2",
@@ -1443,7 +1443,7 @@ class TestSourceNatRuleAddressMapping:
         )
         assert rule.address_mapping == "random"
 
-    def test_address_mapping_persistent(self):
+    def test_address_mapping_persistent(self) -> None:
         """Test source NAT rule with persistent address mapping."""
         rule = SourceNatRule(
             outbound_interface="eth2",
@@ -1453,7 +1453,7 @@ class TestSourceNatRuleAddressMapping:
         )
         assert rule.address_mapping == "persistent"
 
-    def test_address_mapping_none(self):
+    def test_address_mapping_none(self) -> None:
         """Test source NAT rule without address mapping (default VyOS behavior)."""
         rule = SourceNatRule(
             outbound_interface="eth2",
@@ -1462,12 +1462,11 @@ class TestSourceNatRuleAddressMapping:
         )
         assert rule.address_mapping is None
 
-    def test_address_mapping_with_masquerade(self):
-        """Test that address_mapping can be used with masquerade."""
-        rule = SourceNatRule(
-            outbound_interface="eth2",
-            translation="masquerade",
-            address_mapping="random",
-        )
-        assert rule.translation == "masquerade"
-        assert rule.address_mapping == "random"
+    def test_address_mapping_with_masquerade(self) -> None:
+        """Test that address_mapping cannot be used with masquerade."""
+        with pytest.raises(ValidationError, match="address_mapping can only be used with translation_address"):
+            SourceNatRule(
+                outbound_interface="eth2",
+                translation="masquerade",
+                address_mapping="random",
+            )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1464,7 +1464,9 @@ class TestSourceNatRuleAddressMapping:
 
     def test_address_mapping_with_masquerade(self) -> None:
         """Test that address_mapping cannot be used with masquerade."""
-        with pytest.raises(ValidationError, match="address_mapping can only be used with translation_address"):
+        with pytest.raises(
+            ValidationError, match="address_mapping can only be used with translation_address"
+        ):
             SourceNatRule(
                 outbound_interface="eth2",
                 translation="masquerade",


### PR DESCRIPTION
## Summary

Implements IP hopping support through NAT address pool randomization and conntrack timeout configuration as specified in #168.

## Changes

### NAT Address Mapping
- Added `address_mapping` field to `SourceNatRule` model supporting `random` and `persistent` modes
- Updated `NatGenerator` to emit `translation options address-mapping` commands
- Non-deterministic address selection from pools when set to `random`

### Conntrack Timeout Configuration
- New `ConntrackTimeoutRule` model for custom timeout rules
- New `ConntrackConfig` container model
- New `ConntrackGenerator` to emit VyOS conntrack timeout commands
- Protocol-specific timeout fields (TCP/UDP/ICMP) with validation
- Supports source/destination address matching

### Integration
- Added `conntrack` field to `RouterConfig`
- Added `CONNTRACK_JSON` parsing in `ContextParser`
- Wired up conntrack generator in command generation pipeline

### Documentation
- Updated `docs/context-reference.md` with:
  - `address_mapping` field documentation in NAT_JSON
  - Complete CONNTRACK_JSON schema and examples
  - IP hopping use case combining both features

### Testing
- 29 new unit tests for models and generators
- All 449 tests passing
- Full coverage of new functionality

## Usage Example

```json
{
  "NAT_JSON": {
    "source": [{
      "outbound_interface": "eth2",
      "source_address": "10.60.0.0/14",
      "translation_address": "10.97.0.0-10.103.255.254",
      "address_mapping": "random"
    }]
  },
  "CONNTRACK_JSON": {
    "timeout_rules": [{
      "description": "IP hopping - short idle timeout",
      "source_address": "10.60.0.0/14",
      "protocol": "tcp",
      "tcp_established": 60
    }]
  }
}
```

## Acceptance Criteria

- [x] `address_mapping` field added to SourceNatRule with validation
- [x] NAT generator emits `translation options address-mapping` when set
- [x] Conntrack timeout custom rules model and generator implemented
- [x] Documentation updated with IP hopping example
- [x] Unit tests for new functionality
- [x] All tests passing (449 total)

## References

Closes #168

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>