### PR TITLE
ci: Auto-cancel superseded workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary

Adds concurrency settings to automatically cancel in-progress runs when a new commit is pushed to the same branch.

Fixes #174

## Changes

Added to `.github/workflows/ci.yml`:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Benefit

Prevents obsolete jobs from consuming self-hosted runner capacity when multiple commits are pushed to a PR branch in quick succession.

---

🤖 Generated with Claude Code (Opus 4.5)