### PR TITLE
fix(parser): handle empty strings for optional IPv4 fields

### DIFF
--- a/src/vyos_onecontext/parser.py
+++ b/src/vyos_onecontext/parser.py
@@ -287,13 +287,18 @@ class ContextParser:
             # Parse management flag
             management = management_str == "YES" if management_str else False
 
+            # Convert empty strings to None for optional IPv4Address fields
+            # This prevents Pydantic validation errors when OpenNebula provides empty strings
+            gateway_value = gateway if gateway else None
+            dns_value = dns if dns else None
+
             interfaces.append(
                 InterfaceConfig(
                     name=f"eth{eth_num}",
                     ip=ip,  # type: ignore[arg-type]  # Pydantic converts str to IPv4Address
                     mask=mask,
-                    gateway=gateway,  # type: ignore[arg-type]  # Pydantic converts str to IPv4Address
-                    dns=dns,  # type: ignore[arg-type]  # Pydantic converts str to IPv4Address
+                    gateway=gateway_value,  # type: ignore[arg-type]  # Pydantic converts str to IPv4Address
+                    dns=dns_value,  # type: ignore[arg-type]  # Pydantic converts str to IPv4Address
                     mtu=mtu,
                     management=management,
                 )


### PR DESCRIPTION
## Problem

Production routers are failing contextualization with Pydantic validation errors:
```
Input is not a valid IPv4 address [type=ip_v4_address, input_value='', input_type=str]
```

OpenNebula can provide empty strings for optional `ETHx_GATEWAY` and `ETHx_DNS` fields. The parser was passing these empty strings directly to Pydantic's `IPv4Address` validator, which rejects empty strings.

## Solution

Convert empty strings to `None` before passing to `InterfaceConfig`, matching the existing pattern used for alias masks (line 337-338).

**Changed lines**: `src/vyos_onecontext/parser.py:290-296`

```python
# Convert empty strings to None for optional IPv4Address fields
gateway_value = gateway if gateway else None
dns_value = dns if dns else None
```

## Testing

Added comprehensive test coverage in `TestEmptyOptionalFields`:
- Empty gateway and DNS (main regression test)
- Empty gateway with valid DNS
- Valid gateway with empty DNS  
- Missing gateway and DNS

All 486 tests pass, including 4 new tests.

## Impact

This is a **critical production bugfix**. Without this fix, routers cannot boot when OpenNebula provides empty strings for optional network fields.

## Review Notes

- Similar fix already exists for alias masks (line 337-338)
- Only affects shell variable parsing, not JSON-parsed configs
- Other optional IPv4 fields (routes, OSPF, NAT) are JSON-parsed and not affected

---

Generated with [Claude Code](https://claude.com/claude-code)