### PR TITLE
Phase 1: Pydantic models for VRF-based relay configuration

### DIFF
--- a/src/vyos_onecontext/models/__init__.py
+++ b/src/vyos_onecontext/models/__init__.py
@@ -20,6 +20,7 @@ from vyos_onecontext.models.nat import (
     NatConfig,
     SourceNatRule,
 )
+from vyos_onecontext.models.relay import PivotConfig, RelayConfig, RelayTarget
 from vyos_onecontext.models.routing import (
     OspfConfig,
     OspfDefaultInformation,
@@ -51,6 +52,10 @@ __all__ = [
     "DestinationNatRule",
     "NatConfig",
     "SourceNatRule",
+    # relay
+    "PivotConfig",
+    "RelayConfig",
+    "RelayTarget",
     # routing
     "OspfConfig",
     "OspfDefaultInformation",

--- a/src/vyos_onecontext/models/relay.py
+++ b/src/vyos_onecontext/models/relay.py
@@ -1,0 +1,123 @@
+"""Relay configuration models for VRF-based scoring relay."""
+
+from __future__ import annotations
+
+from ipaddress import IPv4Address, IPv4Network
+from typing import Annotated
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from vyos_onecontext.models.interface import _validate_interface_name
+
+
+class RelayTarget(BaseModel):
+    """A single relay target (relay prefix -> target network).
+
+    Defines a mapping from a relay address range (visible to scoring) to an
+    actual target network address range, with subnet-to-subnet NAT translation.
+    """
+
+    relay_prefix: Annotated[str, Field(description="Relay address range (CIDR notation)")]
+    target_prefix: Annotated[str, Field(description="Target network range (CIDR notation)")]
+    gateway: Annotated[IPv4Address, Field(description="Next-hop gateway for target network")]
+
+    @field_validator("relay_prefix", "target_prefix")
+    @classmethod
+    def validate_prefix(cls, v: str) -> str:
+        """Validate IPv4 CIDR notation."""
+        try:
+            IPv4Network(v, strict=False)
+        except ValueError as e:
+            raise ValueError(f"Invalid CIDR notation: {v}") from e
+        return v
+
+    @model_validator(mode="after")
+    def validate_prefix_lengths_match(self) -> RelayTarget:
+        """Ensure relay_prefix and target_prefix have matching prefix lengths.
+
+        VyOS subnet-to-subnet NAT (netmap) requires identical prefix lengths.
+        """
+        relay_net = IPv4Network(self.relay_prefix, strict=False)
+        target_net = IPv4Network(self.target_prefix, strict=False)
+        if relay_net.prefixlen != target_net.prefixlen:
+            raise ValueError(
+                f"relay_prefix ({self.relay_prefix}) and target_prefix "
+                f"({self.target_prefix}) must have matching prefix lengths"
+            )
+        return self
+
+
+class PivotConfig(BaseModel):
+    """A routing pivot (egress interface + targets).
+
+    A pivot represents a routing domain (VRF) with one egress interface and
+    one or more target networks reachable via that interface.
+    """
+
+    egress_interface: Annotated[str, Field(description="Egress interface for this pivot")]
+    targets: Annotated[list[RelayTarget], Field(description="Target networks for this pivot")]
+
+    @field_validator("egress_interface")
+    @classmethod
+    def validate_interface_format(cls, v: str) -> str:
+        """Validate interface name format."""
+        return _validate_interface_name(v)
+
+    @model_validator(mode="after")
+    def validate_has_targets(self) -> PivotConfig:
+        """Ensure at least one target per pivot."""
+        if not self.targets:
+            raise ValueError("Each pivot must have at least one target")
+        return self
+
+
+class RelayConfig(BaseModel):
+    """Complete relay router configuration.
+
+    Defines VRF-based relay configuration with ingress interface and multiple
+    routing pivots, each handling traffic to different target networks.
+    """
+
+    ingress_interface: Annotated[str, Field(description="Interface receiving relay traffic")]
+    pivots: Annotated[list[PivotConfig], Field(description="Routing pivots (VRFs)")]
+
+    @field_validator("ingress_interface")
+    @classmethod
+    def validate_interface_format(cls, v: str) -> str:
+        """Validate interface name format."""
+        return _validate_interface_name(v)
+
+    @model_validator(mode="after")
+    def validate_relay_config(self) -> RelayConfig:
+        """Cross-reference validation across entire relay configuration."""
+        # Ensure at least one pivot
+        if not self.pivots:
+            raise ValueError("At least one pivot is required")
+
+        # Check unique egress interfaces
+        egress_ifaces = [p.egress_interface for p in self.pivots]
+        if len(egress_ifaces) != len(set(egress_ifaces)):
+            duplicates = sorted(
+                {iface for iface in egress_ifaces if egress_ifaces.count(iface) > 1}
+            )
+            raise ValueError(f"Duplicate egress interfaces: {duplicates}")
+
+        # Check ingress != egress
+        if self.ingress_interface in egress_ifaces:
+            raise ValueError(
+                f"ingress_interface ({self.ingress_interface}) cannot be "
+                "used as an egress_interface"
+            )
+
+        # Check no overlapping relay prefixes
+        relay_prefixes = [
+            target.relay_prefix for pivot in self.pivots for target in pivot.targets
+        ]
+        # Convert to IPv4Network for overlap detection
+        relay_networks = [IPv4Network(p, strict=False) for p in relay_prefixes]
+        for i, net1 in enumerate(relay_networks):
+            for net2 in relay_networks[i + 1 :]:
+                if net1.overlaps(net2):
+                    raise ValueError(f"Overlapping relay prefixes: {net1} and {net2}")
+
+        return self

--- a/tests/test_relay_models.py
+++ b/tests/test_relay_models.py
@@ -1,0 +1,348 @@
+"""Tests for relay configuration models."""
+
+import pytest
+from pydantic import ValidationError
+
+from vyos_onecontext.models import PivotConfig, RelayConfig, RelayTarget
+
+
+class TestRelayTarget:
+    """Tests for RelayTarget model."""
+
+    def test_valid_target(self) -> None:
+        """Test valid relay target configuration."""
+        target = RelayTarget(
+            relay_prefix="10.32.5.0/24",
+            target_prefix="192.168.144.0/24",
+            gateway="192.168.100.1",
+        )
+        assert target.relay_prefix == "10.32.5.0/24"
+        assert target.target_prefix == "192.168.144.0/24"
+        assert str(target.gateway) == "192.168.100.1"
+
+    def test_various_prefix_lengths(self) -> None:
+        """Test relay targets with various CIDR prefix lengths."""
+        # /16
+        target_16 = RelayTarget(
+            relay_prefix="10.32.0.0/16",
+            target_prefix="192.168.0.0/16",
+            gateway="192.168.100.1",
+        )
+        assert target_16.relay_prefix == "10.32.0.0/16"
+
+        # /28
+        target_28 = RelayTarget(
+            relay_prefix="10.32.5.0/28",
+            target_prefix="192.168.144.0/28",
+            gateway="192.168.100.1",
+        )
+        assert target_28.relay_prefix == "10.32.5.0/28"
+
+        # /25
+        target_25 = RelayTarget(
+            relay_prefix="10.36.105.0/25",
+            target_prefix="10.127.105.0/25",
+            gateway="10.127.105.1",
+        )
+        assert target_25.relay_prefix == "10.36.105.0/25"
+
+    def test_mismatched_prefix_lengths(self) -> None:
+        """Test that mismatched prefix lengths are rejected."""
+        with pytest.raises(
+            ValidationError, match="relay_prefix.*target_prefix.*matching prefix lengths"
+        ):
+            RelayTarget(
+                relay_prefix="10.32.5.0/24",
+                target_prefix="192.168.144.0/25",
+                gateway="192.168.100.1",
+            )
+
+    def test_invalid_relay_prefix(self) -> None:
+        """Test that invalid relay prefix is rejected."""
+        with pytest.raises(ValidationError, match="Invalid CIDR notation"):
+            RelayTarget(
+                relay_prefix="10.32.5.0/33",  # Invalid prefix length
+                target_prefix="192.168.144.0/24",
+                gateway="192.168.100.1",
+            )
+
+    def test_invalid_target_prefix(self) -> None:
+        """Test that invalid target prefix is rejected."""
+        with pytest.raises(ValidationError, match="Invalid CIDR notation"):
+            RelayTarget(
+                relay_prefix="10.32.5.0/24",
+                target_prefix="not-a-cidr",
+                gateway="192.168.100.1",
+            )
+
+    def test_invalid_gateway(self) -> None:
+        """Test that invalid gateway IP is rejected."""
+        with pytest.raises(ValidationError):
+            RelayTarget(
+                relay_prefix="10.32.5.0/24",
+                target_prefix="192.168.144.0/24",
+                gateway="999.999.999.999",  # type: ignore
+            )
+
+
+class TestPivotConfig:
+    """Tests for PivotConfig model."""
+
+    def test_valid_pivot_single_target(self) -> None:
+        """Test valid pivot with single target."""
+        pivot = PivotConfig(
+            egress_interface="eth2",
+            targets=[
+                RelayTarget(
+                    relay_prefix="10.32.5.0/24",
+                    target_prefix="192.168.144.0/24",
+                    gateway="192.168.100.1",
+                )
+            ],
+        )
+        assert pivot.egress_interface == "eth2"
+        assert len(pivot.targets) == 1
+
+    def test_valid_pivot_multiple_targets(self) -> None:
+        """Test valid pivot with multiple targets."""
+        pivot = PivotConfig(
+            egress_interface="eth2",
+            targets=[
+                RelayTarget(
+                    relay_prefix="10.32.5.0/24",
+                    target_prefix="192.168.144.0/24",
+                    gateway="192.168.100.1",
+                ),
+                RelayTarget(
+                    relay_prefix="10.33.5.0/24",
+                    target_prefix="10.123.105.0/24",
+                    gateway="192.168.100.1",
+                ),
+            ],
+        )
+        assert len(pivot.targets) == 2
+
+    def test_empty_targets_list(self) -> None:
+        """Test that empty targets list is rejected."""
+        with pytest.raises(ValidationError, match="at least one target"):
+            PivotConfig(egress_interface="eth2", targets=[])
+
+    def test_invalid_interface_format(self) -> None:
+        """Test that invalid interface format is rejected."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            PivotConfig(
+                egress_interface="wlan0",  # Not ethN format
+                targets=[
+                    RelayTarget(
+                        relay_prefix="10.32.5.0/24",
+                        target_prefix="192.168.144.0/24",
+                        gateway="192.168.100.1",
+                    )
+                ],
+            )
+
+    def test_interface_not_ethN(self) -> None:
+        """Test that non-ethN interface names are rejected."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            PivotConfig(
+                egress_interface="ens192",
+                targets=[
+                    RelayTarget(
+                        relay_prefix="10.32.5.0/24",
+                        target_prefix="192.168.144.0/24",
+                        gateway="192.168.100.1",
+                    )
+                ],
+            )
+
+
+class TestRelayConfig:
+    """Tests for RelayConfig model."""
+
+    def test_minimal_valid_config(self) -> None:
+        """Test minimal valid relay configuration."""
+        config = RelayConfig(
+            ingress_interface="eth1",
+            pivots=[
+                PivotConfig(
+                    egress_interface="eth2",
+                    targets=[
+                        RelayTarget(
+                            relay_prefix="10.32.5.0/24",
+                            target_prefix="192.168.144.0/24",
+                            gateway="192.168.100.1",
+                        )
+                    ],
+                )
+            ],
+        )
+        assert config.ingress_interface == "eth1"
+        assert len(config.pivots) == 1
+
+    def test_multiple_pivots_multiple_targets(self) -> None:
+        """Test configuration with multiple pivots and targets."""
+        config = RelayConfig(
+            ingress_interface="eth1",
+            pivots=[
+                PivotConfig(
+                    egress_interface="eth2",
+                    targets=[
+                        RelayTarget(
+                            relay_prefix="10.32.5.0/24",
+                            target_prefix="192.168.144.0/24",
+                            gateway="192.168.100.1",
+                        ),
+                        RelayTarget(
+                            relay_prefix="10.33.5.0/24",
+                            target_prefix="10.123.105.0/24",
+                            gateway="192.168.100.1",
+                        ),
+                    ],
+                ),
+                PivotConfig(
+                    egress_interface="eth3",
+                    targets=[
+                        RelayTarget(
+                            relay_prefix="10.36.5.0/24",
+                            target_prefix="10.101.105.0/24",
+                            gateway="10.101.105.1",
+                        ),
+                        RelayTarget(
+                            relay_prefix="10.36.105.0/25",
+                            target_prefix="10.127.105.0/25",
+                            gateway="10.127.105.1",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        assert len(config.pivots) == 2
+        assert len(config.pivots[0].targets) == 2
+        assert len(config.pivots[1].targets) == 2
+
+    def test_empty_pivots_list(self) -> None:
+        """Test that empty pivots list is rejected."""
+        with pytest.raises(ValidationError, match="At least one pivot is required"):
+            RelayConfig(ingress_interface="eth1", pivots=[])
+
+    def test_duplicate_egress_interfaces(self) -> None:
+        """Test that duplicate egress interfaces are rejected."""
+        with pytest.raises(ValidationError, match="Duplicate egress interfaces.*eth2"):
+            RelayConfig(
+                ingress_interface="eth1",
+                pivots=[
+                    PivotConfig(
+                        egress_interface="eth2",
+                        targets=[
+                            RelayTarget(
+                                relay_prefix="10.32.5.0/24",
+                                target_prefix="192.168.144.0/24",
+                                gateway="192.168.100.1",
+                            )
+                        ],
+                    ),
+                    PivotConfig(
+                        egress_interface="eth2",  # Duplicate
+                        targets=[
+                            RelayTarget(
+                                relay_prefix="10.33.5.0/24",
+                                target_prefix="10.123.105.0/24",
+                                gateway="192.168.100.1",
+                            )
+                        ],
+                    ),
+                ],
+            )
+
+    def test_ingress_equals_egress(self) -> None:
+        """Test that ingress interface cannot be used as egress."""
+        with pytest.raises(
+            ValidationError, match="ingress_interface.*cannot be used as an egress_interface"
+        ):
+            RelayConfig(
+                ingress_interface="eth1",
+                pivots=[
+                    PivotConfig(
+                        egress_interface="eth1",  # Same as ingress
+                        targets=[
+                            RelayTarget(
+                                relay_prefix="10.32.5.0/24",
+                                target_prefix="192.168.144.0/24",
+                                gateway="192.168.100.1",
+                            )
+                        ],
+                    )
+                ],
+            )
+
+    def test_overlapping_relay_prefixes_same_pivot(self) -> None:
+        """Test that overlapping relay prefixes are rejected (same pivot)."""
+        with pytest.raises(ValidationError, match="Overlapping relay prefixes"):
+            RelayConfig(
+                ingress_interface="eth1",
+                pivots=[
+                    PivotConfig(
+                        egress_interface="eth2",
+                        targets=[
+                            RelayTarget(
+                                relay_prefix="10.32.5.0/24",
+                                target_prefix="192.168.144.0/24",
+                                gateway="192.168.100.1",
+                            ),
+                            RelayTarget(
+                                relay_prefix="10.32.5.0/25",  # Overlaps with /24
+                                target_prefix="10.123.105.0/25",
+                                gateway="192.168.100.1",
+                            ),
+                        ],
+                    )
+                ],
+            )
+
+    def test_overlapping_relay_prefixes_different_pivots(self) -> None:
+        """Test that overlapping relay prefixes are rejected (different pivots)."""
+        with pytest.raises(ValidationError, match="Overlapping relay prefixes"):
+            RelayConfig(
+                ingress_interface="eth1",
+                pivots=[
+                    PivotConfig(
+                        egress_interface="eth2",
+                        targets=[
+                            RelayTarget(
+                                relay_prefix="10.32.5.0/24",
+                                target_prefix="192.168.144.0/24",
+                                gateway="192.168.100.1",
+                            )
+                        ],
+                    ),
+                    PivotConfig(
+                        egress_interface="eth3",
+                        targets=[
+                            RelayTarget(
+                                relay_prefix="10.32.5.0/24",  # Exact duplicate
+                                target_prefix="10.123.105.0/24",
+                                gateway="10.123.105.1",
+                            )
+                        ],
+                    ),
+                ],
+            )
+
+    def test_invalid_ingress_interface_format(self) -> None:
+        """Test that invalid ingress interface format is rejected."""
+        with pytest.raises(ValidationError, match="Invalid interface name"):
+            RelayConfig(
+                ingress_interface="wlan0",
+                pivots=[
+                    PivotConfig(
+                        egress_interface="eth2",
+                        targets=[
+                            RelayTarget(
+                                relay_prefix="10.32.5.0/24",
+                                target_prefix="192.168.144.0/24",
+                                gateway="192.168.100.1",
+                            )
+                        ],
+                    )
+                ],
+            )


### PR DESCRIPTION
## Summary

Implements Phase 1 of the VRF-based scoring relay feature: Pydantic models with comprehensive validation for relay router configuration.

This is the first phase of a multi-phase implementation described in the [relay design document](https://github.com/SouthwestCCDC/vyos-onecontext/blob/issue-20-relay-design/docs/relay-design.md).

### Changes

- **New file**: `src/vyos_onecontext/models/relay.py` with three Pydantic models:
  - `RelayTarget`: Maps relay prefix to target network with gateway
  - `PivotConfig`: Groups targets by egress interface (routing domain)
  - `RelayConfig`: Complete relay configuration with cross-validation
- **Updated**: `src/vyos_onecontext/models/__init__.py` to export relay models
- **New file**: `tests/test_relay_models.py` with 19 comprehensive test cases

### Validation Rules Implemented

- Relay/target prefix lengths must match (VyOS netmap requirement)
- No overlapping relay prefixes across all targets
- Unique egress interfaces (one VRF per interface)
- Ingress interface cannot be used as egress
- Valid ethN interface format (reuses `_validate_interface_name()` helper)
- Valid IPv4 CIDR notation for all prefixes
- Valid IPv4Address for gateways
- At least one pivot and one target per pivot required

### Design Adherence

This implementation follows the [relay design document](https://github.com/SouthwestCCDC/vyos-onecontext/blob/issue-20-relay-design/docs/relay-design.md) specifications:

- JSON schema (lines 41-83)
- Validation rules (lines 97-109)
- Pydantic models (lines 237-345)

### Test Coverage

All 19 test cases pass, covering:
- Valid configurations (minimal, various prefix lengths, multiple targets/pivots)
- Invalid CIDR notation
- Mismatched prefix lengths
- Invalid interface formats
- Empty targets/pivots lists
- Duplicate egress interfaces
- Ingress interface used as egress
- Overlapping relay prefixes (same and different pivots)
- Invalid gateway IPs

## Test Plan

- [x] All existing tests pass (736 tests total)
- [x] New relay model tests pass (19 tests)
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] Models follow existing patterns from `models/nat.py` and `models/interface.py`
- [x] Reuses `_validate_interface_name()` helper from `models/interface.py`

## Next Steps

This PR completes Phase 1. Subsequent phases:

- Phase 2: Relay generator (VRF, PBR, NAT, routing, proxy-ARP commands)
- Phase 3: Parser integration (RELAY_JSON variable)
- Phase 4: Boot flow integration + RouterConfig changes
- Phase 5: Integration testing on real VyOS Sagitta
- Phase 6: Packer template + Terraform module

Generated with [Claude Code](https://claude.com/claude-code) w/ Sonnet 4.5