### PR TITLE
Phase 3+4: Parser and boot flow integration for relay config

### DIFF
--- a/src/vyos_onecontext/generators/relay.py
+++ b/src/vyos_onecontext/generators/relay.py
@@ -85,6 +85,38 @@ class RelayGenerator(BaseGenerator):
 
         return commands
 
+    def generate_vrf_commands(self) -> list[str]:
+        """Generate VRF creation and interface binding commands.
+
+        Must be called BEFORE interface IP configuration.
+
+        Returns:
+            List of VyOS 'set' commands for VRF configuration
+        """
+        if self.relay is None:
+            return []
+        return self._generate_vrfs()
+
+    def generate_relay_commands(self) -> list[str]:
+        """Generate PBR, NAT, proxy-ARP, and static route commands.
+
+        Must be called AFTER interface IP configuration.
+
+        Returns:
+            List of VyOS 'set' commands for relay configuration (excluding VRF creation)
+        """
+        if self.relay is None:
+            return []
+
+        commands: list[str] = []
+        commands.extend(self._generate_pbr())
+        commands.extend(self._generate_dnat())
+        commands.extend(self._generate_snat())
+        commands.extend(self._generate_proxy_arp())
+        commands.extend(self._generate_static_routes())
+
+        return commands
+
     def _generate_vrfs(self) -> list[str]:
         """Create VRFs and bind interfaces.
 

--- a/src/vyos_onecontext/parser.py
+++ b/src/vyos_onecontext/parser.py
@@ -17,6 +17,7 @@ from vyos_onecontext.models.dhcp import DhcpConfig
 from vyos_onecontext.models.firewall import FirewallConfig
 from vyos_onecontext.models.interface import AliasConfig, InterfaceConfig
 from vyos_onecontext.models.nat import NatConfig
+from vyos_onecontext.models.relay import RelayConfig
 from vyos_onecontext.models.routing import OspfConfig, RoutesConfig
 from vyos_onecontext.models.system import ConntrackConfig
 
@@ -66,6 +67,7 @@ class ContextParser:
         nat = self._parse_nat()
         firewall = self._parse_firewall()
         conntrack = self._parse_conntrack()
+        relay = self._parse_relay()
 
         # Parse operational variables
         hostname = self.variables.get("HOSTNAME")
@@ -90,6 +92,7 @@ class ContextParser:
             nat=nat,
             firewall=firewall,
             conntrack=conntrack,
+            relay=relay,
             start_config=start_config,
             start_script=start_script,
             start_script_timeout=start_script_timeout,
@@ -499,6 +502,14 @@ class ContextParser:
             ConntrackConfig or None if not present
         """
         return self._parse_json_variable("CONNTRACK_JSON", ConntrackConfig)
+
+    def _parse_relay(self) -> RelayConfig | None:
+        """Parse RELAY_JSON variable.
+
+        Returns:
+            RelayConfig or None if not present
+        """
+        return self._parse_json_variable("RELAY_JSON", RelayConfig)
 
 
 def parse_context(


### PR DESCRIPTION
## Summary

Implements Phase 3 (Parser Integration) and Phase 4 (Boot Flow Integration) for VRF-based scoring relay contextualization.

- Parser recognizes `RELAY_JSON` context variable
- RouterConfig validates relay interface references
- RelayGenerator split for two-phase boot flow
- Relay commands integrated into generate_config() sequence

## Changes

### Phase 3: Parser Integration
- Add `_parse_relay()` method to `ContextParser`
- Import `RelayConfig` model
- Pass relay config to `RouterConfig` constructor
- Add parser tests for RELAY_JSON (valid, missing, malformed)

### Phase 4a: RouterConfig Changes
- Add `relay: RelayConfig | None` field to RouterConfig (after conntrack, before escape hatches)
- Add `validate_relay_interface_references()` validator:
  - Ensures `relay.ingress_interface` exists in `interfaces`
  - Ensures each `pivot.egress_interface` exists in `interfaces`
  - Prevents relay interfaces from being management interfaces
- Add comprehensive validation tests

### Phase 4b: RelayGenerator Split
Add two new public methods for split execution:
- `generate_vrf_commands()`: VRF creation + interface binding (runs before interface IPs)
- `generate_relay_commands()`: PBR + NAT + proxy-ARP + static routes (runs after interface IPs)

Keep existing `generate()` method for backward compatibility and test simplicity.

### Phase 4c: Boot Flow Integration
Wire RelayGenerator into `generate_config()` with correct ordering:
1. System config (hostname, SSH keys)
2. Management VRF
3. **Relay VRFs (NEW)** - VRF creation + interface binding
4. Interface IPs
5. **Relay config (NEW)** - PBR + NAT + proxy-ARP + static routes
6. Routing (default gateway)
7. Static routes (ROUTES_JSON)
8. Services (SSH)
9. OSPF
10. DHCP
11. NAT (NAT_JSON)
12. Firewall
13. Conntrack
14. Custom config (START_CONFIG)

## Test Coverage

Added tests for:
- Parser: valid RELAY_JSON parsing, missing RELAY_JSON (relay=None)
- RouterConfig validation:
  - Non-existent ingress interface
  - Non-existent egress interface
  - Management interface as ingress (rejected)
  - Management interface as egress (rejected)
  - Valid relay configuration (passes)
- Boot flow integration:
  - Relay commands generated when config present
  - No relay commands when config absent
  - Command ordering: VRF commands before interface IPs, PBR/NAT after interface IPs

All existing tests continue to pass (relay=None is the default).

## Design Rationale

The split execution (VRF phase before IPs, rest after IPs) is required because VyOS enforces strict ordering constraints. VRFs must exist before interfaces can be bound to them, and interfaces must be bound to VRFs before IP addresses are configured on those interfaces. This is not a logical preference but a correctness requirement in VyOS Sagitta.

See `docs/relay-design.md` section "Boot Flow Integration" for full details.

## Checklist

- [x] Parser integration tests
- [x] RouterConfig validation tests
- [x] Boot flow integration tests
- [x] All existing tests pass
- [x] `just check` passes (ruff + mypy + pytest)
- [x] Incremental commits with clear messages

## Next Steps

Phase 5: Integration testing on real VyOS Sagitta instance to verify netmap NAT, PBR, VRF routing, and proxy-ARP behavior.

## Related

- Issue: #20
- Previous PRs: #190 (design doc), #191 (models), #194 (generator)

---

🤖 Generated with Claude Code (Sonnet 4.5)