### PR TITLE
Fix relay BASE_TABLE_ID to avoid VyOS table number overflow

### DIFF
--- a/src/vyos_onecontext/generators/relay.py
+++ b/src/vyos_onecontext/generators/relay.py
@@ -29,19 +29,19 @@ class RelayGenerator(BaseGenerator):
     - Static routes in VRF context for target networks
 
     Rule numbering:
-    - VRF table IDs: 200, 201, 202... (sequential per pivot)
+    - VRF table IDs: 150, 151, 152... (sequential per pivot)
     - PBR rules: 10, 20, 30... (sequential per target)
     - DNAT rules: 5000, 5010, 5020... (sequential per target)
     - SNAT rules: 5000, 5010, 5020... (sequential per pivot)
 
     Design decisions:
-    - VRF table IDs start at 200 to avoid conflict with management VRF (table 100)
+    - VRF table IDs start at 150 (management VRF uses 100, VyOS max is 200)
     - NAT rules start at 5000 to avoid conflict with standard NAT (100+ range)
     - PBR rules use increment of 10 to allow manual rule insertion if needed
     - SNAT is per-pivot (not per-target) since all targets in a pivot share egress
     """
 
-    BASE_TABLE_ID = 200  # Start VRF table IDs at 200 (management VRF uses 100)
+    BASE_TABLE_ID = 150  # Start VRF table IDs at 150 (management VRF uses 100, VyOS max is 200)
     DNAT_RULE_START = 5000  # Avoid conflict with standard NAT (idx*100 scheme)
     SNAT_RULE_START = 5000
     PBR_RULE_START = 10
@@ -121,7 +121,7 @@ class RelayGenerator(BaseGenerator):
         """Create VRFs and bind interfaces.
 
         Creates one VRF per pivot (egress interface) with sequential table IDs
-        starting at 200. Binds each egress interface to its corresponding VRF.
+        starting at 150. Binds each egress interface to its corresponding VRF.
 
         Returns:
             List of VyOS 'set' commands for VRF configuration

--- a/tests/integration/lib/validate-fixture.sh
+++ b/tests/integration/lib/validate-fixture.sh
@@ -527,12 +527,12 @@ validate_fixture_assertions() {
             assert_command_generated "set vrf name management table 100" "Management VRF creation"
             assert_command_generated "set interfaces ethernet eth0 vrf management" "Management interface VRF assignment"
             # Relay VRF
-            assert_command_generated "set vrf name relay_eth2 table 200" "Relay VRF creation (table 200)"
+            assert_command_generated "set vrf name relay_eth2 table 150" "Relay VRF creation (table 150)"
             assert_command_generated "set interfaces ethernet eth2 vrf relay_eth2" "Egress interface VRF binding"
             # PBR (policy-based routing)
             assert_command_generated "set policy route relay-pbr rule 10" "PBR rule for relay traffic"
             assert_command_generated "set policy route relay-pbr rule 10 destination address 10.40.5.0/24" "PBR destination match"
-            assert_command_generated "set policy route relay-pbr rule 10 set table 200" "PBR table assignment"
+            assert_command_generated "set policy route relay-pbr rule 10 set table 150" "PBR table assignment"
             assert_command_generated "set interfaces ethernet eth1 policy route relay-pbr" "PBR applied to ingress interface"
             # DNAT (netmap - subnet-to-subnet translation)
             assert_command_generated "set nat destination rule 5000" "Relay DNAT rule"

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -3868,7 +3868,7 @@ class TestGenerateConfigWithRelay:
         commands = generate_config(config)
 
         # Check VRF commands are present
-        assert any("set vrf name relay_eth2 table 200" in cmd for cmd in commands)
+        assert any("set vrf name relay_eth2 table 150" in cmd for cmd in commands)
         assert any("set interfaces ethernet eth2 vrf relay_eth2" in cmd for cmd in commands)
 
         # Check PBR commands are present

--- a/tests/test_relay_generator.py
+++ b/tests/test_relay_generator.py
@@ -48,12 +48,12 @@ class TestRelayGenerator:
 
         # Expected commands (in order):
         # 1. VRF creation and interface binding
-        assert "set vrf name relay_eth2 table 200" in commands
+        assert "set vrf name relay_eth2 table 150" in commands
         assert "set interfaces ethernet eth2 vrf relay_eth2" in commands
 
         # 2. Policy-based routing
         assert "set policy route relay-pbr rule 10 destination address 10.32.5.0/24" in commands
-        assert "set policy route relay-pbr rule 10 set table 200" in commands
+        assert "set policy route relay-pbr rule 10 set table 150" in commands
         assert "set interfaces ethernet eth1 policy route relay-pbr" in commands
 
         # 3. Destination NAT
@@ -155,7 +155,7 @@ class TestRelayGenerator:
 
         This is the full-featured scenario: multiple egress interfaces,
         each with multiple targets. Verifies:
-        - VRF table IDs are sequential (200, 201, ...)
+        - VRF table IDs are sequential (150, 151, ...)
         - PBR rules are sequential across all targets (10, 20, 30, 40)
         - DNAT rules are sequential across all targets (5000, 5010, 5020, 5030)
         - SNAT rules are per-pivot, not per-target
@@ -200,20 +200,20 @@ class TestRelayGenerator:
         commands = gen.generate()
 
         # VRF creation: Two VRFs with sequential table IDs
-        assert "set vrf name relay_eth2 table 200" in commands
-        assert "set vrf name relay_eth3 table 201" in commands
+        assert "set vrf name relay_eth2 table 150" in commands
+        assert "set vrf name relay_eth3 table 151" in commands
         assert "set interfaces ethernet eth2 vrf relay_eth2" in commands
         assert "set interfaces ethernet eth3 vrf relay_eth3" in commands
 
         # PBR: Four rules (one per target) with correct table routing
         assert "set policy route relay-pbr rule 10 destination address 10.32.5.0/24" in commands
-        assert "set policy route relay-pbr rule 10 set table 200" in commands
+        assert "set policy route relay-pbr rule 10 set table 150" in commands
         assert "set policy route relay-pbr rule 20 destination address 10.33.5.0/24" in commands
-        assert "set policy route relay-pbr rule 20 set table 200" in commands
+        assert "set policy route relay-pbr rule 20 set table 150" in commands
         assert "set policy route relay-pbr rule 30 destination address 10.36.5.0/24" in commands
-        assert "set policy route relay-pbr rule 30 set table 201" in commands
+        assert "set policy route relay-pbr rule 30 set table 151" in commands
         assert "set policy route relay-pbr rule 40 destination address 10.36.105.0/25" in commands
-        assert "set policy route relay-pbr rule 40 set table 201" in commands
+        assert "set policy route relay-pbr rule 40 set table 151" in commands
 
         # DNAT: Four rules (one per target) with sequential numbering
         dnat_rules = [cmd for cmd in commands if cmd.startswith("set nat destination rule")]
@@ -285,7 +285,7 @@ class TestRelayGenerator:
         commands = gen.generate()
 
         # Find indices of key commands
-        vrf_create_idx = commands.index("set vrf name relay_eth2 table 200")
+        vrf_create_idx = commands.index("set vrf name relay_eth2 table 150")
         vrf_bind_idx = commands.index("set interfaces ethernet eth2 vrf relay_eth2")
         pbr_rule_idx = next(
             i for i, cmd in enumerate(commands) if "policy route relay-pbr rule" in cmd
@@ -337,14 +337,14 @@ class TestRelayGenerator:
         commands = gen.generate()
 
         # Verify VRF name follows convention
-        assert "set vrf name relay_eth5 table 200" in commands
+        assert "set vrf name relay_eth5 table 150" in commands
         assert "set interfaces ethernet eth5 vrf relay_eth5" in commands
         assert any("vrf name relay_eth5 protocols static route" in cmd for cmd in commands)
 
     def test_rule_number_ranges(self):
         """Test that rule numbers fall in expected ranges.
 
-        - VRF table IDs: 200+
+        - VRF table IDs: 150+
         - PBR rules: 10+, increment by 10
         - DNAT rules: 5000+, increment by 10
         - SNAT rules: 5000+, increment by 10
@@ -383,9 +383,9 @@ class TestRelayGenerator:
         gen = RelayGenerator(relay)
         commands = gen.generate()
 
-        # VRF table IDs: 200, 201
-        assert "table 200" in " ".join(commands)
-        assert "table 201" in " ".join(commands)
+        # VRF table IDs: 150, 151
+        assert "table 150" in " ".join(commands)
+        assert "table 151" in " ".join(commands)
 
         # PBR rules: 10, 20, 30
         assert "rule 10 " in " ".join(commands)


### PR DESCRIPTION
## Summary

- Changed relay `BASE_TABLE_ID` from 200 to 150
- Updated all documentation and tests to reflect the new table ID range
- Prevents VyOS boot failure when relay uses 8 pivot points

## Problem

VyOS Sagitta's valid range for policy route table numbers is **1-200**. The relay generator was using `BASE_TABLE_ID = 200`, which generated VRF table IDs 200-207 for 8 pivots. Tables 201-207 are out of range, causing boot failure:

```
set policy route relay-pbr rule 130 set table 201
Exit code 1 Error: Number is not in any of allowed ranges
```

## Solution

Changed `BASE_TABLE_ID` to 150. With 8 pivots, this generates tables 150-157, which:
- Are well clear of management VRF (table 100)
- Stay within VyOS max (200)
- Leave plenty of headroom (50 possible pivots in range 150-200)

## Changes

- `src/vyos_onecontext/generators/relay.py`: Updated constant and comments
- `docs/relay-design.md`: Updated all examples and table ID references
- `tests/test_relay_generator.py`: Updated all test assertions
- `tests/test_generators.py`: Updated integration test assertion

## Test Plan

- [x] All unit tests pass (`just check`)
- [x] Relay generator tests verify correct table IDs (150-157)
- [x] Integration test verifies relay config generation
- [x] Documentation examples match implementation

Generated with [Claude Code](https://claude.com/claude-code) w/ Sonnet 4.5.