### PR TITLE
fix(generator): use Sagitta syntax for PBR interface application

### DIFF
--- a/docs/relay-design.md
+++ b/docs/relay-design.md
@@ -158,7 +158,7 @@ set policy route relay-pbr rule 30 set table 151
 set policy route relay-pbr rule 30 destination address 10.36.5.0/24
 set policy route relay-pbr rule 40 set table 151
 set policy route relay-pbr rule 40 destination address 10.36.105.0/25
-set interfaces ethernet eth1 policy route relay-pbr
+set policy route relay-pbr interface eth1
 ```
 
 **Rule numbering:** Sequential (10, 20, 30, ...) for each relay_prefix
@@ -786,7 +786,7 @@ If netmap isn't supported, we would need to generate per-IP DNAT rules, which is
 ```
 set policy route relay-pbr rule 10 set table 150
 set policy route relay-pbr rule 10 destination address 10.32.5.0/24
-set interfaces ethernet eth1 policy route relay-pbr
+set policy route relay-pbr interface eth1
 ```
 
 **Expected behavior:** Traffic matching destination address is routed to table 150 (VRF routing table).

--- a/src/vyos_onecontext/generators/relay.py
+++ b/src/vyos_onecontext/generators/relay.py
@@ -182,8 +182,7 @@ class RelayGenerator(BaseGenerator):
 
         # Apply policy to ingress interface
         commands.append(
-            f"set interfaces ethernet {self.relay.ingress_interface} "
-            f"policy route relay-pbr"
+            f"set policy route relay-pbr interface {self.relay.ingress_interface}"
         )
 
         return commands

--- a/tests/integration/lib/validate-fixture.sh
+++ b/tests/integration/lib/validate-fixture.sh
@@ -533,7 +533,7 @@ validate_fixture_assertions() {
             assert_command_generated "set policy route relay-pbr rule 10" "PBR rule for relay traffic"
             assert_command_generated "set policy route relay-pbr rule 10 destination address 10.40.5.0/24" "PBR destination match"
             assert_command_generated "set policy route relay-pbr rule 10 set table 150" "PBR table assignment"
-            assert_command_generated "set interfaces ethernet eth1 policy route relay-pbr" "PBR applied to ingress interface"
+            assert_command_generated "set policy route relay-pbr interface eth1" "PBR applied to ingress interface"
             # DNAT (netmap - subnet-to-subnet translation)
             assert_command_generated "set nat destination rule 5000" "Relay DNAT rule"
             assert_command_generated "set nat destination rule 5000 inbound-interface name eth1" "DNAT inbound interface"

--- a/tests/test_relay_generator.py
+++ b/tests/test_relay_generator.py
@@ -54,7 +54,7 @@ class TestRelayGenerator:
         # 2. Policy-based routing
         assert "set policy route relay-pbr rule 10 destination address 10.32.5.0/24" in commands
         assert "set policy route relay-pbr rule 10 set table 150" in commands
-        assert "set interfaces ethernet eth1 policy route relay-pbr" in commands
+        assert "set policy route relay-pbr interface eth1" in commands
 
         # 3. Destination NAT
         assert "set nat destination rule 5000 inbound-interface name eth1" in commands


### PR DESCRIPTION
## Summary

Fix relay policy-based routing (PBR) to use correct Sagitta syntax for interface application.

**Equuleus (1.3.x) - WRONG for Sagitta:**
```
set interfaces ethernet eth1 policy route relay-pbr
```

**Sagitta (1.4.x) - CORRECT:**
```
set policy route relay-pbr interface eth1
```

The interface-based syntax is invalid in Sagitta and causes configuration errors: "configuration path is not valid". The policy-centric command format is required for VyOS 1.4.x.

## Changes

- `src/vyos_onecontext/generators/relay.py`: Updated PBR interface application command
- `tests/test_relay_generator.py`: Fixed test assertions to match Sagitta syntax
- `tests/integration/lib/validate-fixture.sh`: Updated relay fixture validation
- `docs/relay-design.md`: Updated documentation examples (2 occurrences)

## Test plan

- [x] Unit tests pass (`just check`)
- [x] All relay generator tests pass with correct syntax
- [ ] Integration tests on actual VyOS Sagitta instance (pending deployment)

## Notes

This replaces PR #199, which was on a branch already merged as PR #198. This fix is on a clean branch created from `origin/sagitta`.

Addresses #200

Generated with Claude Code w/ Sonnet 4.5