### PR TITLE
Fix relay VM boot failures with environment and timeout fixes

### DIFF
--- a/src/vyos_onecontext/generators/system.py
+++ b/src/vyos_onecontext/generators/system.py
@@ -106,9 +106,9 @@ class SshKeyGenerator(BaseGenerator):
                 f"set system login user vyos authentication public-keys {key_id} type {key_type}"
             )
 
-        # Only enable SSH service if we have at least one valid key
+        # Add key configurations if we have at least one valid key
+        # Note: We don't explicitly set SSH port 22 as VyOS defaults to port 22
         if key_configs:
-            commands.append("set service ssh port 22")
             commands.extend(key_configs)
 
         return commands

--- a/src/vyos_onecontext/wrapper.py
+++ b/src/vyos_onecontext/wrapper.py
@@ -124,9 +124,14 @@ class VyOSConfigSession:
         logger.debug("Running wrapper command: %s", " ".join(cmd))
 
         # Set timeout based on command type
-        # 'commit' can take a long time with complex configs
+        # 'commit' can take a long time with complex configs (relay VMs: 700+ commands)
         # Other commands should be fast
-        timeout = 120 if args and args[0] == "commit" else 30
+        timeout = 600 if args and args[0] == "commit" else 30
+
+        # Ensure VyOS validators can be found by setting vyos_validators_dir
+        # This is normally set by sourcing /etc/default/vyatta
+        env = os.environ.copy()
+        env["vyos_validators_dir"] = "/usr/libexec/vyos/validators"
 
         try:
             result = subprocess.run(
@@ -135,6 +140,7 @@ class VyOSConfigSession:
                 text=True,
                 check=False,
                 timeout=timeout,
+                env=env,
             )
         except subprocess.TimeoutExpired as e:
             raise VyOSConfigError(

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,6 +1,6 @@
 """Unit tests for VyOS configuration wrapper."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -35,6 +35,7 @@ class TestVyOSConfigSession:
             text=True,
             check=False,
             timeout=30,
+            env=ANY,
         )
         assert session._in_session is True
 
@@ -101,6 +102,7 @@ class TestVyOSConfigSession:
             text=True,
             check=False,
             timeout=30,
+            env=ANY,
         )
         assert session._in_session is False
 
@@ -129,6 +131,7 @@ class TestVyOSConfigSession:
             text=True,
             check=False,
             timeout=30,
+            env=ANY,
         )
 
     @patch("subprocess.run")
@@ -167,6 +170,7 @@ class TestVyOSConfigSession:
             text=True,
             check=False,
             timeout=30,
+            env=ANY,
         )
 
     @patch("subprocess.run")
@@ -200,7 +204,8 @@ class TestVyOSConfigSession:
             capture_output=True,
             text=True,
             check=False,
-            timeout=120,
+            timeout=600,
+            env=ANY,
         )
 
     @patch("subprocess.run")
@@ -258,6 +263,7 @@ class TestVyOSConfigSession:
             text=True,
             check=False,
             timeout=30,
+            env=ANY,
         )
 
     @patch("subprocess.run")


### PR DESCRIPTION
## Summary

This PR implements three critical fixes to resolve boot failures on relay VMs:

1. **Source VyOS environment variables in wrapper subprocess calls** - Sets `vyos_validators_dir` in subprocess environment to fix validator path issues
2. **Remove explicit SSH port 22 configuration** - VyOS defaults to port 22; explicit set triggers validator that was failing
3. **Increase commit timeout from 120s to 600s** - Relay VMs generate 700+ commands and need more time

## Context

Relay routers were experiencing boot failures during SSH key configuration. The root cause was missing VyOS environment variables (`vyos_validators_dir`) in subprocess calls, which caused validators to fail. The explicit SSH port configuration triggered this validator, so we removed it (VyOS defaults to port 22 anyway). Additionally, the commit timeout was too short for the large number of commands generated by relay configurations.

## Test Plan

- [x] All existing unit tests pass with updated expectations
- [x] `just check` passes (ruff, mypy, pytest)
- [ ] Manual testing on relay VM boot (requires deployment environment)

## Changes

- Modified `src/vyos_onecontext/wrapper.py`:
  - Added `vyos_validators_dir` to subprocess environment
  - Increased commit timeout from 120s to 600s
- Modified `src/vyos_onecontext/generators/system.py`:
  - Removed `set service ssh port 22` command
- Updated tests to match new behavior

Generated with Claude Code w/ Sonnet 4.5