### PR TITLE
fix(generator): remove loopback routes from relay proxy-ARP configuration

### DIFF
--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -3833,8 +3833,8 @@ class TestGenerateConfigWithRelay:
             interfaces=[
                 InterfaceConfig(
                     name="eth1",
-                    ip=IPv4Address("10.0.1.1"),
-                    mask="255.255.255.0",
+                    ip=IPv4Address("10.40.17.1"),
+                    mask="255.240.0.0",  # /12
                 ),
                 InterfaceConfig(
                     name="eth2",
@@ -3849,7 +3849,7 @@ class TestGenerateConfigWithRelay:
                         egress_interface="eth2",
                         targets=[
                             RelayTarget(
-                                relay_prefix="10.32.5.0/24",
+                                relay_prefix="10.40.5.0/24",  # Within 10.40.0.0/12
                                 target_prefix="192.168.144.0/24",
                                 gateway="192.168.100.1",
                             )
@@ -3905,8 +3905,8 @@ class TestGenerateConfigWithRelay:
             interfaces=[
                 InterfaceConfig(
                     name="eth1",
-                    ip=IPv4Address("10.0.1.1"),
-                    mask="255.255.255.0",
+                    ip=IPv4Address("10.40.17.1"),
+                    mask="255.240.0.0",  # /12
                 ),
                 InterfaceConfig(
                     name="eth2",
@@ -3921,7 +3921,7 @@ class TestGenerateConfigWithRelay:
                         egress_interface="eth2",
                         targets=[
                             RelayTarget(
-                                relay_prefix="10.32.5.0/24",
+                                relay_prefix="10.40.5.0/24",  # Within 10.40.0.0/12
                                 target_prefix="192.168.144.0/24",
                                 gateway="192.168.100.1",
                             )
@@ -3969,8 +3969,8 @@ class TestGenerateConfigWithRelay:
                 ),
                 InterfaceConfig(
                     name="eth1",
-                    ip=IPv4Address("10.0.1.1"),
-                    mask="255.255.255.0",
+                    ip=IPv4Address("10.40.17.1"),
+                    mask="255.240.0.0",  # /12
                 ),
                 InterfaceConfig(
                     name="eth2",
@@ -3985,7 +3985,7 @@ class TestGenerateConfigWithRelay:
                         egress_interface="eth2",
                         targets=[
                             RelayTarget(
-                                relay_prefix="10.32.5.0/24",
+                                relay_prefix="10.40.5.0/24",  # Within 10.40.0.0/12
                                 target_prefix="192.168.144.0/24",
                                 gateway="192.168.100.1",
                             )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -671,7 +671,7 @@ CONNTRACK_JSON='{json.dumps(conntrack_data)}'
                     "egress_interface": "eth2",
                     "targets": [
                         {
-                            "relay_prefix": "10.32.5.0/24",
+                            "relay_prefix": "10.40.5.0/24",
                             "target_prefix": "192.168.144.0/24",
                             "gateway": "192.168.100.1",
                         }
@@ -679,9 +679,9 @@ CONNTRACK_JSON='{json.dumps(conntrack_data)}'
                 }
             ],
         }
-        # Need interfaces to satisfy RouterConfig validation
-        content = f"""ETH1_IP="10.0.1.1"
-ETH1_MASK="255.255.255.0"
+        # Need interfaces with proper subnet coverage for relay validation
+        content = f"""ETH1_IP="10.40.17.1"
+ETH1_MASK="255.240.0.0"
 ETH2_IP="192.168.100.2"
 ETH2_MASK="255.255.255.0"
 RELAY_JSON='{json.dumps(relay_data)}'
@@ -695,7 +695,7 @@ RELAY_JSON='{json.dumps(relay_data)}'
         assert len(config.relay.pivots) == 1
         assert config.relay.pivots[0].egress_interface == "eth2"
         assert len(config.relay.pivots[0].targets) == 1
-        assert config.relay.pivots[0].targets[0].relay_prefix == "10.32.5.0/24"
+        assert config.relay.pivots[0].targets[0].relay_prefix == "10.40.5.0/24"
 
     def test_relay_json_not_present(self, tmp_path: Path) -> None:
         """Test that config without RELAY_JSON has relay=None."""


### PR DESCRIPTION
## Summary
- Removes 96 static routes pointing relay prefixes to loopback interface
- Fixes broken relay data path caused by kernel treating relay addresses as local
- Maintains proxy-ARP functionality via existing /12 subnet on ingress interface

## Problem
The relay VM was generating static routes like:
```
set protocols static route 10.41.37.0/24 interface lo
```

These routes caused the kernel to treat relay addresses (10.40-47.x) as local, preventing them from being forwarded through NAT/PBR. Instead of translating and routing relay traffic to target networks, packets were dropped or mishandled.

## Root Cause
The original implementation incorrectly assumed that Linux proxy-ARP requires routing destinations through a different interface than where ARP requests arrive. This led to adding loopback routes to "trick" proxy-ARP into responding.

## Solution
With the /12 subnet already configured on eth1 (e.g., 10.40.17.1/12 covers all 10.40-47.x addresses), the router correctly owns these addresses and can respond to ARP requests without additional local routes. Proxy-ARP works correctly when:
1. The address is within the subnet configured on the interface
2. The interface has proxy-ARP enabled

No loopback routes are needed.

## Changes
- **relay.py**: Remove loopback route generation from `_generate_proxy_arp()`
- **relay.py**: Update docstring to reflect correct proxy-ARP behavior
- **test_relay_generator.py**: Update tests to verify no loopback routes are generated
- Maintain proxy-ARP enablement on ingress interface

## Testing
- All unit tests pass (`just check`)
- Relay generator tests verify no loopback routes in output
- Proxy-ARP enablement preserved

## Test Plan
- [ ] Verify relay VM boots without loopback routes in config
- [ ] Confirm relay traffic flows through DNAT/SNAT correctly
- [ ] Validate ARP responses for relay addresses on ingress interface
- [ ] Test full relay data path with real traffic

Generated with [Claude Code](https://claude.com/claude-code)