### PR TITLE
fix(packer): use --retry-all-errors for uv installer download

### DIFF
--- a/packer/test-image.pkr.hcl
+++ b/packer/test-image.pkr.hcl
@@ -274,7 +274,7 @@ build {
       # Download uv installer with diagnostics on failure
       <<-INSTALL
       echo "Downloading uv installer..."
-      if ! curl -4 --retry 5 --retry-delay 5 --retry-connrefused -LsSf https://astral.sh/uv/install.sh -o /tmp/uv-install.sh; then
+      if ! curl -4 --retry 5 --retry-delay 5 --retry-all-errors -LsSf https://astral.sh/uv/install.sh -o /tmp/uv-install.sh; then
         echo "ERROR: Failed to download uv installer"
         dns_diag 'CURL DOWNLOAD FAILED'
         exit 1


### PR DESCRIPTION
## Summary

- Replace `--retry-connrefused` with `--retry-all-errors` in the curl command that downloads the `uv` installer in `test-image.pkr.hcl`

QEMU SLIRP can report connection failures with errno values other than `ECONNREFUSED`, so `--retry-connrefused` doesn't trigger retries. `--retry-all-errors` covers all transient failure modes.

The test-image already uses the correct download-to-file pattern (no pipe masking issue), so only the retry flag needs updating.

Companion PR: SouthwestCCDC/deployment (same fix for vrouter-infra and scoring-engine images).

## Test plan

- [ ] CI passes
- [ ] Next test-image build retries on transient network failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)