### PR TITLE
Fix relay ingress VRF to enable cross-VRF PBR

### DIFF
--- a/src/vyos_onecontext/generators/__init__.py
+++ b/src/vyos_onecontext/generators/__init__.py
@@ -57,7 +57,7 @@ def generate_config(config: RouterConfig) -> list[str]:
 
     # Relay VRF configuration - must come BEFORE interface IP configuration
     # Creates VRFs and binds egress interfaces to them
-    relay_gen = RelayGenerator(config.relay)
+    relay_gen = RelayGenerator(config.relay, config.interfaces)
     commands.extend(relay_gen.generate_vrf_commands())
 
     # Interfaces (IP addresses, MTU)


### PR DESCRIPTION
## Summary

- Creates dedicated VRF for relay ingress interface (table ID 149)
- Binds ingress interface to ingress VRF
- Adds default route in ingress VRF for return traffic
- **Adds cross-VRF interface routes to enable kernel proxy-ARP**
- **Adds cross-VRF default routes in egress VRFs for return path routing**
- Enables cross-VRF PBR from ingress VRF to egress VRFs
- Updates tests to expect ingress VRF, default route, proxy-ARP routes, and egress default routes

## Problem

The relay data path was broken for three reasons:

1. **Cross-VRF routing**: The ingress interface was in the global/default VRF while egress interfaces were in per-pivot VRFs. VRF strict mode blocks traffic from global→VRF, so PBR could not route relay traffic to the egress VRFs.

2. **Proxy-ARP not working**: The kernel only performs proxy-ARP when it has a route to the target via a DIFFERENT interface than where the ARP request arrived. Since all relay addresses fall within the /12 connected subnet on the ingress interface, the kernel saw them as "same interface" routes and would not proxy-ARP.

3. **Return path routing**: When reply traffic arrives on an egress interface and conntrack reverses the NAT, the egress VRF had no route back to the original sender in the ingress VRF, causing "ICMP net unreachable" errors.

## Solution

1. **Ingress VRF**: Put the ingress interface in its own VRF (table ID 149) with a default route pointing to the ingress interface gateway. This enables cross-VRF PBR and allows return traffic to reach the scoring engine.

2. **Cross-VRF proxy-ARP routes**: Add static routes in the ingress VRF for each relay prefix pointing to the egress interface via the egress VRF:
   ```
   set vrf name relay_eth1 protocols static route {relay_prefix} interface {egress} vrf relay_{egress}
   ```
   This gives the kernel a route via a different interface, enabling proxy-ARP.

3. **Egress VRF default routes**: Add default routes in each egress VRF pointing back to the ingress VRF gateway:
   ```
   set vrf name relay_{egress} protocols static route 0.0.0.0/0 next-hop {ingress_gateway} vrf relay_{ingress}
   ```
   This enables return traffic routing when replies arrive on egress interfaces.

This matches the pattern used in 2025 regionals relay routers (Equuleus), adapted for Sagitta syntax.

## Changes

1. **Ingress VRF creation**: Creates VRF with table ID 149 and binds ingress interface
2. **Default route in ingress VRF**: Adds `0.0.0.0/0` route to ingress gateway (if configured)
3. **Cross-VRF proxy-ARP routes**: Adds interface routes for each relay prefix to enable kernel proxy-ARP
4. **Egress VRF default routes**: Adds default routes in each egress VRF back to ingress VRF for return path
5. **Interface awareness**: RelayGenerator now accepts interfaces list to look up gateway
6. **Graceful handling**: If ingress interface has no gateway, VRFs are created but without default routes

## Testing

- All existing tests updated to expect ingress VRF commands
- New test for ingress default route generation
- New test for graceful handling when no gateway configured
- Tests updated to expect cross-VRF proxy-ARP routes
- Tests updated to expect egress VRF default routes
- `just check` passes (ruff, mypy, 771 tests)

## Test Plan

- [ ] Deploy relay router with ingress VRF configuration
- [ ] Verify ingress interface is in relay_eth1 VRF with default route
- [ ] Verify cross-VRF interface routes exist for each relay prefix
- [ ] Verify egress VRFs have default routes back to ingress VRF
- [ ] Verify PBR routes traffic from ingress VRF to egress VRFs
- [ ] Verify proxy-ARP works on ingress interface (kernel responds to ARP for relay addresses)
- [ ] Verify relay connectivity from scoring engine to target networks
- [ ] Verify return traffic reaches scoring engine through cross-VRF routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
