### PR TITLE
chore(ci): migrate integration tests to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Install just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
 
       - name: Install dependencies
         run: uv sync --group dev
@@ -33,28 +33,24 @@ jobs:
         run: just check
 
   integration:
-    # Integration tests require KVM - run on self-hosted runners
-    # Only run on push to sagitta or PRs from the same repo (not forks)
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, amd64, kvm]
+    runs-on: ubuntu-latest
     needs: check  # Only run if lint/unit tests pass
 
     steps:
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | \
+            sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # Need full history for git diff
 
-      - name: Verify KVM access
-        run: |
-          if [ ! -e /dev/kvm ]; then
-            echo "ERROR: /dev/kvm not available"
-            exit 1
-          fi
-          echo "KVM is available"
-
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

- Switch integration job from `[self-hosted, amd64, kvm]` to `ubuntu-latest`
- Add KVM enablement step (udev rules) as the first step in the integration job — required to get `/dev/kvm` access on GitHub-hosted runners
- Remove fork guard `if:` condition — no longer needed since GitHub-hosted runners don't expose secrets to forks by default
- Remove now-redundant "Verify KVM access" step
- Pin all action versions (`actions/checkout`, `astral-sh/setup-uv`, `extractions/setup-just`) to full commit SHAs with `# vN` tag comments for supply-chain hardening

Closes #209

## Test plan

- [ ] Verify CI workflow triggers on push/PR to sagitta
- [ ] Confirm integration job runs on ubuntu-latest (not self-hosted)
- [ ] Confirm KVM is available inside the job (`/dev/kvm` exists after Enable KVM step)
- [ ] Confirm integration tests pass end-to-end

---

AI-generated via Claude Code w/ Claude Sonnet 4.6