### PR TITLE
fix(generator): emit comma-separated ports for destination_port list

### DIFF
--- a/src/vyos_onecontext/generators/firewall.py
+++ b/src/vyos_onecontext/generators/firewall.py
@@ -234,19 +234,17 @@ class FirewallGenerator(BaseGenerator):
 
                 # Destination port filters (inline or port-group)
                 if rule.destination_port is not None:
-                    # Handle both single port and list of ports
+                    # Handle both single port and list of ports.
+                    # VyOS accepts comma-separated values for multiple ports in a
+                    # single `set` command; separate commands would overwrite each other.
                     if isinstance(rule.destination_port, list):
-                        # For multiple ports, generate separate commands for each
-                        for port in rule.destination_port:
-                            commands.append(
-                                f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
-                                f"destination port {port}"
-                            )
+                        port_value = ",".join(str(p) for p in rule.destination_port)
                     else:
-                        commands.append(
-                            f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
-                            f"destination port {rule.destination_port}"
-                        )
+                        port_value = str(rule.destination_port)
+                    commands.append(
+                        f"set firewall ipv4 name {ruleset_name} rule {rule_num} "
+                        f"destination port {port_value}"
+                    )
                 if rule.destination_port_group:
                     commands.append(
                         f"set firewall ipv4 name {ruleset_name} rule {rule_num} "

--- a/src/vyos_onecontext/models/firewall.py
+++ b/src/vyos_onecontext/models/firewall.py
@@ -139,6 +139,8 @@ class FirewallRule(BaseModel):
         """Validate that destination port(s) are valid."""
         if v is None:
             return None
+        if isinstance(v, list) and len(v) == 0:
+            raise ValueError("destination_port list must not be empty")
         ports = [v] if isinstance(v, int) else v
         for port in ports:
             if not 1 <= port <= 65535:

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -3344,8 +3344,8 @@ class TestFirewallGenerator:
         assert "set firewall ipv4 name GAME-to-SCORING rule 100 protocol tcp_udp" in commands
         assert "set firewall ipv4 name GAME-to-SCORING rule 100 destination port 53" in commands
 
-    def test_generate_policy_with_multiple_inline_ports(self):
-        """Test policy rule with multiple inline destination ports."""
+    def test_generate_policy_with_single_destination_port(self):
+        """Test policy rule with a single destination_port int."""
         firewall = FirewallConfig(
             zones={
                 "GAME": FirewallZone(name="GAME", interfaces=["eth1"], default_action="drop"),
@@ -3359,7 +3359,37 @@ class TestFirewallGenerator:
                         FirewallRule(
                             action="accept",
                             protocol="tcp",
-                            destination_port=[80, 443, 8080],
+                            destination_port=80,
+                        )
+                    ],
+                )
+            ],
+        )
+        gen = FirewallGenerator(firewall)
+        commands = gen.generate()
+
+        assert "set firewall ipv4 name GAME-to-SCORING rule 100 destination port 80" in commands
+
+    def test_generate_policy_with_multiple_inline_ports(self):
+        """Test policy rule with multiple inline destination ports.
+
+        VyOS set on a leaf node overwrites rather than appends, so multiple
+        ports must be expressed as a single comma-separated value.
+        """
+        firewall = FirewallConfig(
+            zones={
+                "GAME": FirewallZone(name="GAME", interfaces=["eth1"], default_action="drop"),
+                "SCORING": FirewallZone(name="SCORING", interfaces=["eth2"], default_action="drop"),
+            },
+            policies=[
+                FirewallPolicy(
+                    from_zone="GAME",
+                    to_zone="SCORING",
+                    rules=[
+                        FirewallRule(
+                            action="accept",
+                            protocol="tcp",
+                            destination_port=[80, 443],
                             description="Allow multiple web ports",
                         )
                     ],
@@ -3369,10 +3399,17 @@ class TestFirewallGenerator:
         gen = FirewallGenerator(firewall)
         commands = gen.generate()
 
-        # Each port should get its own command
-        assert "set firewall ipv4 name GAME-to-SCORING rule 100 destination port 80" in commands
-        assert "set firewall ipv4 name GAME-to-SCORING rule 100 destination port 443" in commands
-        assert "set firewall ipv4 name GAME-to-SCORING rule 100 destination port 8080" in commands
+        # Ports must be in a single comma-separated command, not separate commands
+        port_commands = [
+            c for c in commands
+            if "destination port" in c and "GAME-to-SCORING rule 100" in c
+        ]
+        assert len(port_commands) == 1, (
+            f"Expected exactly one port command, got {len(port_commands)}: {port_commands}"
+        )
+        assert port_commands[0] == (
+            "set firewall ipv4 name GAME-to-SCORING rule 100 destination port 80,443"
+        )
 
     def test_generate_multiple_policies(self):
         """Test multiple inter-zone policies."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -749,6 +749,22 @@ class TestValidationEnhancements:
                 destination_port_group="WEB",
             )
 
+    def test_firewall_rule_destination_port_empty_list_rejected(self) -> None:
+        """Test that FirewallRule rejects an empty destination_port list.
+
+        An empty list would cause the generator to emit `destination port ` (no value),
+        which is invalid VyOS syntax.
+        """
+        with pytest.raises(
+            ValidationError,
+            match="destination_port list must not be empty",
+        ):
+            FirewallRule(
+                action="accept",
+                protocol="tcp",
+                destination_port=[],
+            )
+
     def test_firewall_config_invalid_zone_reference(self) -> None:
         """Test that FirewallConfig rejects policies referencing non-existent zones."""
         with pytest.raises(ValidationError, match="non-existent from_zone"):


### PR DESCRIPTION
## Summary

- Fixes #211: when `destination_port` is a list (e.g. `[80, 443]`), the generator previously emitted a separate `set` command for each port. VyOS overwrites leaf nodes on `set`, so only the last port survived.
- Now emits a single `destination port 80,443` command (valid VyOS syntax).
- Single `int` values continue to work as before.
- Updates the existing `test_generate_policy_with_multiple_inline_ports` test (which was asserting the broken behavior) and adds `test_generate_policy_with_single_destination_port`.

## Test plan

- [x] `test_generate_policy_with_single_destination_port` — verifies single int emits `destination port 80`
- [x] `test_generate_policy_with_multiple_inline_ports` — verifies list `[80, 443]` emits exactly one `destination port 80,443` command (asserts `len == 1`)
- [x] `just check` passes (789 passed, 20 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code) w/ Claude Sonnet 4.6