### PR TITLE
fix(model): coerce empty SSH_PUBLIC_KEY to None instead of crashing

### DIFF
--- a/src/vyos_onecontext/models/config.py
+++ b/src/vyos_onecontext/models/config.py
@@ -89,7 +89,7 @@ class RouterConfig(BaseModel):
         Raises:
             ValueError: If SSH key format is invalid
         """
-        if v is None:
+        if v is None or v.strip() == "":
             return None
 
         # SSH key format: type key [comment]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1501,6 +1501,20 @@ class TestInputValidation:
         router = RouterConfig(ssh_public_key=None)
         assert router.ssh_public_key is None
 
+    def test_ssh_key_empty_string_coerced_to_none(self) -> None:
+        """Test that empty string SSH key is coerced to None.
+
+        OpenNebula passes empty string (not null) when a user has no
+        SSH_PUBLIC_KEY configured. This must not crash contextualization.
+        """
+        router = RouterConfig(ssh_public_key="")
+        assert router.ssh_public_key is None
+
+    def test_ssh_key_whitespace_only_coerced_to_none(self) -> None:
+        """Test that whitespace-only SSH key is coerced to None."""
+        router = RouterConfig(ssh_public_key="   ")
+        assert router.ssh_public_key is None
+
     def test_interface_name_valid_eth0(self) -> None:
         """Test valid eth0 interface name."""
         iface = InterfaceConfig(name="eth0", ip="10.0.1.1", mask="255.255.255.0")


### PR DESCRIPTION
## Summary

- Empty/whitespace-only `SSH_PUBLIC_KEY` from OpenNebula context is now coerced to `None` in `validate_ssh_key()` instead of raising a `ValidationError`
- Fixes relay VMs (and all VMs) crashing at boot when the ONE user has no SSH key configured
- Adds two test cases covering empty string and whitespace-only input

## Details

When OpenNebula substitutes `$USER[SSH_PUBLIC_KEY]` and the user has no SSH key, ONE passes an empty string (not null). The Pydantic validator rejected this with a `ValidationError` that was uncaught, crashing the entire contextualization pipeline -- no interfaces, NAT, or routing would be configured.

The fix adds an early return in `validate_ssh_key()`:
```python
if v is None or v.strip() == "":
    return None
```

This is the most defensive approach -- handling coercion at the validation layer rather than requiring every caller to sanitize input.

## Test plan

- [x] New test: empty string SSH key coerced to None
- [x] New test: whitespace-only SSH key coerced to None
- [x] All existing SSH key validation tests still pass
- [x] `just check` passes (ruff + mypy + pytest, 812 tests)

Generated with Claude Code (Claude Opus 4.6 w/ 1M context)