### PR TITLE
feat(generator): add SNMP_COMMUNITY context variable for SNMP configuration

### DIFF
--- a/src/vyos_onecontext/generators/__init__.py
+++ b/src/vyos_onecontext/generators/__init__.py
@@ -14,7 +14,7 @@ from vyos_onecontext.generators.nat import NatGenerator
 from vyos_onecontext.generators.ospf import OspfGenerator
 from vyos_onecontext.generators.relay import RelayGenerator
 from vyos_onecontext.generators.routing import RoutingGenerator, StaticRoutesGenerator
-from vyos_onecontext.generators.service import SshServiceGenerator
+from vyos_onecontext.generators.service import SnmpGenerator, SshServiceGenerator
 from vyos_onecontext.generators.system import (
     ConntrackGenerator,
     HostnameGenerator,
@@ -38,7 +38,7 @@ def generate_config(config: RouterConfig) -> list[str]:
     6. Relay configuration continued (if RELAY_JSON present - PBR, NAT, proxy-ARP, static routes)
     7. Routing (default gateway selection for non-management interfaces)
     8. Static routes (ROUTES_JSON; may reference VRFs)
-    9. Services (SSH VRF binding)
+    9. Services (SSH VRF binding, SNMP)
     10. Dynamic routing (OSPF)
     11. DHCP server
     12. NAT (source, destination, binat)
@@ -99,8 +99,9 @@ def generate_config(config: RouterConfig) -> list[str]:
     # Static routes (ROUTES_JSON) - must come AFTER VRF since routes can reference VRFs
     commands.extend(StaticRoutesGenerator(config.routes).generate())
 
-    # Services (SSH VRF binding)
+    # Services (SSH VRF binding, SNMP)
     commands.extend(SshServiceGenerator(config.interfaces).generate())
+    commands.extend(SnmpGenerator(config.snmp_community, config.interfaces).generate())
 
     # OSPF dynamic routing
     commands.extend(OspfGenerator(config.ospf).generate())
@@ -134,6 +135,7 @@ __all__ = [
     "OspfGenerator",
     "RelayGenerator",
     "RoutingGenerator",
+    "SnmpGenerator",
     "SshKeyGenerator",
     "SshServiceGenerator",
     "StartConfigGenerator",

--- a/src/vyos_onecontext/generators/service.py
+++ b/src/vyos_onecontext/generators/service.py
@@ -1,8 +1,12 @@
 """Service configuration generators for VRF-aware services."""
 
+import logging
+
 from vyos_onecontext.generators.base import BaseGenerator
 from vyos_onecontext.generators.vrf import VRF_NAME
 from vyos_onecontext.models import InterfaceConfig
+
+logger = logging.getLogger(__name__)
 
 
 class SshServiceGenerator(BaseGenerator):
@@ -35,3 +39,54 @@ class SshServiceGenerator(BaseGenerator):
             return []
 
         return [f"set service ssh vrf {VRF_NAME}"]
+
+
+class SnmpGenerator(BaseGenerator):
+    """Generate SNMP service configuration.
+
+    Configures SNMP with a read-only community string, bound to the first
+    management interface IP address.
+    """
+
+    def __init__(self, snmp_community: str | None, interfaces: list[InterfaceConfig]):
+        """Initialize SNMP generator.
+
+        Args:
+            snmp_community: SNMP community string, or None to skip SNMP configuration
+            interfaces: List of interface configurations (used to find management IP)
+        """
+        self.snmp_community = snmp_community
+        self.interfaces = interfaces
+
+    def generate(self) -> list[str]:
+        """Generate SNMP service commands.
+
+        Emits two VyOS commands: one to configure a read-only community and one
+        to bind SNMP to the first management interface IP. If no management
+        interface is found, logs a warning and returns an empty list.
+
+        Returns:
+            List of VyOS 'set' commands for SNMP service configuration
+        """
+        if self.snmp_community is None:
+            return []
+
+        # Find the first management interface IP
+        mgmt_iface = next(
+            (iface for iface in self.interfaces if iface.management),
+            None,
+        )
+
+        if mgmt_iface is None:
+            logger.warning(
+                "SNMP_COMMUNITY is set but no management interface found; "
+                "skipping SNMP listen-address configuration"
+            )
+            return []
+
+        mgmt_ip = str(mgmt_iface.ip)
+
+        return [
+            f"set service snmp community {self.snmp_community} authorization ro",
+            f"set service snmp listen-address {mgmt_ip}",
+        ]

--- a/src/vyos_onecontext/generators/service.py
+++ b/src/vyos_onecontext/generators/service.py
@@ -80,7 +80,7 @@ class SnmpGenerator(BaseGenerator):
         if mgmt_iface is None:
             logger.warning(
                 "SNMP_COMMUNITY is set but no management interface found; "
-                "skipping SNMP listen-address configuration"
+                "skipping SNMP configuration entirely"
             )
             return []
 

--- a/src/vyos_onecontext/generators/service.py
+++ b/src/vyos_onecontext/generators/service.py
@@ -45,7 +45,8 @@ class SnmpGenerator(BaseGenerator):
     """Generate SNMP service configuration.
 
     Configures SNMP with a read-only community string, bound to the first
-    management interface IP address.
+    management interface IP address. When a management VRF exists, also
+    binds SNMP to the VRF so the daemon runs in the correct network namespace.
     """
 
     def __init__(self, snmp_community: str | None, interfaces: list[InterfaceConfig]):
@@ -61,9 +62,13 @@ class SnmpGenerator(BaseGenerator):
     def generate(self) -> list[str]:
         """Generate SNMP service commands.
 
-        Emits two VyOS commands: one to configure a read-only community and one
-        to bind SNMP to the first management interface IP. If no management
-        interface is found, logs a warning and returns an empty list.
+        Emits VyOS commands to configure a read-only community and bind SNMP
+        to the first management interface IP. When a management VRF exists,
+        also emits a VRF binding so snmpd runs in the correct namespace
+        (without this, SNMP is unreachable on VRF-bound interfaces).
+
+        If no management interface is found, logs a warning and returns
+        an empty list.
 
         Returns:
             List of VyOS 'set' commands for SNMP service configuration
@@ -86,7 +91,16 @@ class SnmpGenerator(BaseGenerator):
 
         mgmt_ip = str(mgmt_iface.ip)
 
-        return [
+        commands = [
             f"set service snmp community {self.snmp_community} authorization ro",
             f"set service snmp listen-address {mgmt_ip}",
         ]
+
+        # Bind SNMP to management VRF so snmpd runs in the correct namespace.
+        # Without this, snmpd in the default VRF cannot receive traffic on
+        # VRF-bound interfaces (see VyOS T2321, T5340).
+        has_management_vrf = any(iface.management for iface in self.interfaces)
+        if has_management_vrf:
+            commands.append(f"set service snmp vrf {VRF_NAME}")
+
+        return commands

--- a/src/vyos_onecontext/models/config.py
+++ b/src/vyos_onecontext/models/config.py
@@ -211,6 +211,50 @@ class RouterConfig(BaseModel):
     conntrack: Annotated[
         ConntrackConfig | None, Field(None, description="Conntrack timeout configuration")
     ]
+    snmp_community: Annotated[
+        str | None, Field(None, description="SNMP community string for read-only access")
+    ]
+
+    @field_validator("snmp_community")
+    @classmethod
+    def validate_snmp_community(cls, v: str | None) -> str | None:
+        """Validate snmp_community is a safe single-token value.
+
+        Performs a safe-character check: rejects values containing whitespace,
+        quotes, or shell-special characters. Allows alphanumeric characters,
+        hyphens, and underscores (common in SNMP community strings such as
+        "sw_monitoring_2026" or "public").
+
+        Note: This is a safe-token check, not an SNMP specification check.
+        Values that pass may still be rejected by VyOS at commit time.
+
+        Args:
+            v: SNMP community string to validate
+
+        Returns:
+            The validated community string (stripped), or None if blank
+
+        Raises:
+            ValueError: If the value contains unsafe characters
+        """
+        if v is None:
+            return None
+
+        v = v.strip()
+        if not v:
+            return None
+
+        # Allow only safe characters: alphanumeric, hyphens, underscores.
+        # No whitespace, quotes, or shell-special characters.
+        pattern = r"^[a-zA-Z0-9_\-]+$"
+        if not re.match(pattern, v):
+            raise ValueError(
+                f"Invalid snmp_community: {v!r} (must contain only alphanumeric characters, "
+                f"hyphens, and underscores; whitespace, quotes, and special characters are "
+                f"not allowed)"
+            )
+
+        return v
 
     # Relay
     relay: Annotated[RelayConfig | None, Field(None, description="VRF-based relay configuration")]

--- a/src/vyos_onecontext/parser.py
+++ b/src/vyos_onecontext/parser.py
@@ -75,6 +75,7 @@ class ContextParser:
         hostname = self.variables.get("HOSTNAME")
         ssh_public_key = self.variables.get("SSH_PUBLIC_KEY")
         syslog_host = self.variables.get("SYSLOG_HOST")
+        snmp_community = self.variables.get("SNMP_COMMUNITY")
         onecontext_mode = self._parse_onecontext_mode()
 
         # Parse escape hatches
@@ -87,6 +88,7 @@ class ContextParser:
             hostname=hostname,
             ssh_public_key=ssh_public_key,
             syslog_host=syslog_host,
+            snmp_community=snmp_community,
             onecontext_mode=onecontext_mode,
             interfaces=interfaces,
             aliases=aliases,

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -12,6 +12,7 @@ from vyos_onecontext.generators import (
     NatGenerator,
     OspfGenerator,
     RoutingGenerator,
+    SnmpGenerator,
     SshKeyGenerator,
     SshServiceGenerator,
     StartConfigGenerator,
@@ -4221,3 +4222,131 @@ class TestSyslogGenerator:
         commands = generate_config(config)
 
         assert not any("syslog" in cmd for cmd in commands)
+
+
+class TestSnmpGenerator:
+    """Tests for SNMP service configuration generator."""
+
+    def _mgmt_iface(self, ip: str = "10.0.0.1") -> InterfaceConfig:
+        """Return a management InterfaceConfig for the given IP."""
+        return InterfaceConfig(
+            name="eth0",
+            ip=IPv4Address(ip),
+            mask="255.255.255.0",
+            management=True,
+        )
+
+    def _data_iface(self, ip: str = "172.16.0.1") -> InterfaceConfig:
+        """Return a non-management InterfaceConfig for the given IP."""
+        return InterfaceConfig(
+            name="eth1",
+            ip=IPv4Address(ip),
+            mask="255.255.255.0",
+            management=False,
+        )
+
+    def test_generate_basic(self):
+        """Generate two SNMP commands with community and management IP."""
+        gen = SnmpGenerator("public", [self._mgmt_iface("10.0.0.1")])
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert commands[0] == "set service snmp community public authorization ro"
+        assert commands[1] == "set service snmp listen-address 10.0.0.1"
+
+    def test_generate_with_underscore_community(self):
+        """Community strings with underscores and digits are accepted."""
+        gen = SnmpGenerator("sw_monitoring_2026", [self._mgmt_iface("192.168.1.5")])
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert commands[0] == "set service snmp community sw_monitoring_2026 authorization ro"
+        assert commands[1] == "set service snmp listen-address 192.168.1.5"
+
+    def test_generate_uses_first_management_interface(self):
+        """When multiple management interfaces exist, only the first one is used."""
+        interfaces = [
+            InterfaceConfig(
+                name="eth0",
+                ip=IPv4Address("10.0.0.1"),
+                mask="255.255.255.0",
+                management=True,
+            ),
+            InterfaceConfig(
+                name="eth1",
+                ip=IPv4Address("10.0.1.1"),
+                mask="255.255.255.0",
+                management=True,
+            ),
+        ]
+        gen = SnmpGenerator("public", interfaces)
+        commands = gen.generate()
+
+        assert len(commands) == 2
+        assert "10.0.0.1" in commands[1]
+        assert "10.0.1.1" not in commands[1]
+
+    def test_generate_none_community(self):
+        """No commands emitted when snmp_community is None."""
+        gen = SnmpGenerator(None, [self._mgmt_iface()])
+        commands = gen.generate()
+
+        assert len(commands) == 0
+
+    def test_generate_no_management_interface(self):
+        """No commands and a warning logged when no management interface exists."""
+        gen = SnmpGenerator("public", [self._data_iface()])
+        commands = gen.generate()
+
+        assert len(commands) == 0
+
+    def test_generate_no_management_interface_warning(self, caplog):
+        """Warning is logged when SNMP community is set but no management interface exists."""
+        import logging
+
+        gen = SnmpGenerator("public", [self._data_iface()])
+        with caplog.at_level(logging.WARNING, logger="vyos_onecontext.generators.service"):
+            gen.generate()
+
+        assert any("no management interface" in record.message for record in caplog.records)
+
+    def test_generate_empty_interface_list(self):
+        """No commands emitted when interface list is empty."""
+        gen = SnmpGenerator("public", [])
+        commands = gen.generate()
+
+        assert len(commands) == 0
+
+    def test_generate_config_includes_snmp(self):
+        """generate_config includes SNMP commands when snmp_community is set."""
+        config = RouterConfig(
+            snmp_community="public",
+            interfaces=[
+                InterfaceConfig(
+                    name="eth0",
+                    ip=IPv4Address("10.0.0.1"),
+                    mask="255.255.255.0",
+                    management=True,
+                )
+            ],
+        )
+        commands = generate_config(config)
+
+        assert "set service snmp community public authorization ro" in commands
+        assert "set service snmp listen-address 10.0.0.1" in commands
+
+    def test_generate_config_excludes_snmp_when_unset(self):
+        """generate_config emits no SNMP commands when snmp_community is None."""
+        config = RouterConfig(
+            snmp_community=None,
+            interfaces=[
+                InterfaceConfig(
+                    name="eth0",
+                    ip=IPv4Address("10.0.0.1"),
+                    mask="255.255.255.0",
+                )
+            ],
+        )
+        commands = generate_config(config)
+
+        assert not any("snmp" in cmd for cmd in commands)

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -4246,22 +4246,24 @@ class TestSnmpGenerator:
         )
 
     def test_generate_basic(self):
-        """Generate two SNMP commands with community and management IP."""
+        """Generate SNMP commands with community, listen-address, and VRF."""
         gen = SnmpGenerator("public", [self._mgmt_iface("10.0.0.1")])
         commands = gen.generate()
 
-        assert len(commands) == 2
+        assert len(commands) == 3
         assert commands[0] == "set service snmp community public authorization ro"
         assert commands[1] == "set service snmp listen-address 10.0.0.1"
+        assert commands[2] == "set service snmp vrf management"
 
     def test_generate_with_underscore_community(self):
         """Community strings with underscores and digits are accepted."""
         gen = SnmpGenerator("sw_monitoring_2026", [self._mgmt_iface("192.168.1.5")])
         commands = gen.generate()
 
-        assert len(commands) == 2
+        assert len(commands) == 3
         assert commands[0] == "set service snmp community sw_monitoring_2026 authorization ro"
         assert commands[1] == "set service snmp listen-address 192.168.1.5"
+        assert commands[2] == "set service snmp vrf management"
 
     def test_generate_uses_first_management_interface(self):
         """When multiple management interfaces exist, only the first one is used."""
@@ -4282,7 +4284,7 @@ class TestSnmpGenerator:
         gen = SnmpGenerator("public", interfaces)
         commands = gen.generate()
 
-        assert len(commands) == 2
+        assert len(commands) == 3
         assert "10.0.0.1" in commands[1]
         assert "10.0.1.1" not in commands[1]
 
@@ -4334,6 +4336,7 @@ class TestSnmpGenerator:
 
         assert "set service snmp community public authorization ro" in commands
         assert "set service snmp listen-address 10.0.0.1" in commands
+        assert "set service snmp vrf management" in commands
 
     def test_generate_config_excludes_snmp_when_unset(self):
         """generate_config emits no SNMP commands when snmp_community is None."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1561,6 +1561,68 @@ class TestInputValidation:
         router = RouterConfig(syslog_host=None)
         assert router.syslog_host is None
 
+    # --- snmp_community validator tests ---
+
+    def test_snmp_community_valid_simple(self) -> None:
+        """Test that a simple community string like 'public' is accepted."""
+        router = RouterConfig(snmp_community="public")
+        assert router.snmp_community == "public"
+
+    def test_snmp_community_valid_alphanumeric(self) -> None:
+        """Test that an alphanumeric community string is accepted."""
+        router = RouterConfig(snmp_community="monitoring2026")
+        assert router.snmp_community == "monitoring2026"
+
+    def test_snmp_community_valid_with_underscores(self) -> None:
+        """Test that underscores are permitted in community strings."""
+        router = RouterConfig(snmp_community="sw_monitoring_2026")
+        assert router.snmp_community == "sw_monitoring_2026"
+
+    def test_snmp_community_valid_with_hyphens(self) -> None:
+        """Test that hyphens are permitted in community strings."""
+        router = RouterConfig(snmp_community="mon-2026")
+        assert router.snmp_community == "mon-2026"
+
+    def test_snmp_community_invalid_shell_injection(self) -> None:
+        """Test that shell injection characters are rejected."""
+        with pytest.raises(ValidationError, match="Invalid snmp_community"):
+            RouterConfig(snmp_community="public; rm -rf /")
+
+    def test_snmp_community_invalid_whitespace(self) -> None:
+        """Test that embedded whitespace is rejected."""
+        with pytest.raises(ValidationError, match="Invalid snmp_community"):
+            RouterConfig(snmp_community="my community")
+
+    def test_snmp_community_invalid_single_quote(self) -> None:
+        """Test that single quote is rejected."""
+        with pytest.raises(ValidationError, match="Invalid snmp_community"):
+            RouterConfig(snmp_community="pub'lic")
+
+    def test_snmp_community_invalid_double_quote(self) -> None:
+        """Test that double quote is rejected."""
+        with pytest.raises(ValidationError, match="Invalid snmp_community"):
+            RouterConfig(snmp_community='pub"lic')
+
+    def test_snmp_community_invalid_pipe(self) -> None:
+        """Test that pipe character is rejected."""
+        with pytest.raises(ValidationError, match="Invalid snmp_community"):
+            RouterConfig(snmp_community="pub|lic")
+
+    def test_snmp_community_empty_string_becomes_none(self) -> None:
+        """Test that empty string becomes None."""
+        router = RouterConfig(snmp_community="")
+        assert router.snmp_community is None
+
+    def test_snmp_community_whitespace_only_becomes_none(self) -> None:
+        """Test that whitespace-only string becomes None."""
+        router = RouterConfig(snmp_community="   ")
+        assert router.snmp_community is None
+
+    def test_snmp_community_none_passthrough(self) -> None:
+        """Test that None passes through unchanged."""
+        router = RouterConfig(snmp_community=None)
+        assert router.snmp_community is None
+
     def test_interface_name_valid_eth0(self) -> None:
         """Test valid eth0 interface name."""
         iface = InterfaceConfig(name="eth0", ip="10.0.1.1", mask="255.255.255.0")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -518,6 +518,31 @@ SYSLOG_HOST="mon.infra.swccdc.com"
 
         assert config.syslog_host == "mon.infra.swccdc.com"
 
+    def test_snmp_community(self, tmp_path: Path) -> None:
+        """Test SNMP_COMMUNITY parsing."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+SNMP_COMMUNITY="sw_monitoring_2026"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert config.snmp_community == "sw_monitoring_2026"
+
+    def test_snmp_community_absent(self, tmp_path: Path) -> None:
+        """Test that SNMP_COMMUNITY defaults to None when absent."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.1.1"
+ETH0_MASK="255.255.255.0"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert config.snmp_community is None
+
 
 class TestJsonVariables:
     """Tests for JSON variable parsing."""


### PR DESCRIPTION
## Summary

- Adds `SNMP_COMMUNITY` context variable that generates VyOS SNMP service configuration
- When set, emits `set service snmp community <community> authorization ro` and `set service snmp listen-address <mgmt-ip>` (bound to the first management interface IP)
- Validates the community string as a safe token: allows alphanumeric, hyphens, underscores; rejects whitespace, quotes, and shell metacharacters

## Changes

- **`models/config.py`**: `snmp_community: str | None` field with `validate_snmp_community` validator following the `validate_syslog_host` pattern
- **`generators/service.py`**: `SnmpGenerator` class — no-ops when community is None or no management interface; logs a warning when management interface is absent
- **`generators/__init__.py`**: imports `SnmpGenerator`, wires it into `generate_config`, adds to `__all__`
- **`parser.py`**: reads `SNMP_COMMUNITY` and passes it to `RouterConfig`
- **Tests**: `TestSnmpGenerator` (generator + `generate_config` integration), `snmp_community` validator tests in `test_models.py`, parser integration in `test_parser.py`

## Test plan

- [x] `just check` — 833 tests pass, 0 failures

Closes #3309

*AI-generated via Claude Code w/ Claude Sonnet 4.6*