### PR TITLE
feat(parser): support ETHx_IGNORE_GATEWAY to suppress default routes

### DIFF
--- a/src/vyos_onecontext/parser.py
+++ b/src/vyos_onecontext/parser.py
@@ -305,6 +305,9 @@ class ContextParser:
                 raise ValueError(f"Interface {prefix} has IP but no MASK")
 
             gateway = self.variables.get(f"{prefix}_GATEWAY")
+            ignore_gateway = self.variables.get(f"{prefix}_IGNORE_GATEWAY", "")
+            if ignore_gateway.strip().lower() == "yes":
+                gateway = None
             dns = self.variables.get(f"{prefix}_DNS")
             mtu_str = self.variables.get(f"{prefix}_MTU")
             management_str = self.variables.get(f"{prefix}_VROUTER_MANAGEMENT")

--- a/src/vyos_onecontext/parser.py
+++ b/src/vyos_onecontext/parser.py
@@ -5,6 +5,7 @@ and converts shell variable assignments into validated Pydantic models.
 """
 
 import json
+import logging
 import re
 from pathlib import Path
 from typing import TypeVar
@@ -21,6 +22,8 @@ from vyos_onecontext.models.relay import RelayConfig
 from vyos_onecontext.models.routing import OspfConfig, RoutesConfig
 from vyos_onecontext.models.system import ConntrackConfig
 from vyos_onecontext.models.vxlan import VxlanConfig
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -82,6 +85,9 @@ class ContextParser:
         start_config = self.variables.get("START_CONFIG")
         start_script = self.variables.get("START_SCRIPT")
         start_script_timeout = self._parse_start_script_timeout()
+
+        # Apply GATEWAY_IFACE post-processing: suppress gateways on non-gateway interfaces
+        interfaces = self._apply_gateway_iface(interfaces)
 
         # Build and validate complete configuration
         return RouterConfig(
@@ -342,6 +348,39 @@ class ContextParser:
             )
 
         return interfaces
+
+    def _apply_gateway_iface(self, interfaces: list[InterfaceConfig]) -> list[InterfaceConfig]:
+        """Apply GATEWAY_IFACE post-processing to suppress gateways.
+
+        If GATEWAY_IFACE is set to an integer index N, only eth{N} keeps its
+        gateway; all other interfaces have their gateway nulled out.
+
+        Args:
+            interfaces: List of parsed interface configurations
+
+        Returns:
+            Updated list with gateways nulled on non-gateway interfaces
+        """
+        gateway_iface_str = self.variables.get("GATEWAY_IFACE")
+        if gateway_iface_str is None:
+            return interfaces
+
+        try:
+            gateway_index = int(gateway_iface_str)
+        except ValueError:
+            logger.warning(
+                "GATEWAY_IFACE=%r is not a valid integer; leaving all gateways unchanged",
+                gateway_iface_str,
+            )
+            return interfaces
+
+        gateway_iface_name = f"eth{gateway_index}"
+        return [
+            iface
+            if iface.name == gateway_iface_name
+            else iface.model_copy(update={"gateway": None})
+            for iface in interfaces
+        ]
 
     def _parse_aliases(self, interfaces: list[InterfaceConfig]) -> list[AliasConfig]:
         """Parse ETHx_ALIASy_* variables into AliasConfig objects.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,7 @@
 """Tests for context file parser."""
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -1471,3 +1472,94 @@ ETH1_IGNORE_GATEWAY="yes"
         eth1 = next(i for i in config.interfaces if i.name == "eth1")
         assert str(eth0.gateway) == "10.0.0.254"
         assert eth1.gateway is None
+
+
+class TestGatewayIface:
+    """Tests for GATEWAY_IFACE default-route selection."""
+
+    def test_gateway_iface_1_preserves_eth1_suppresses_eth0(self, tmp_path: Path) -> None:
+        """GATEWAY_IFACE=1 keeps eth1 gateway and nulls eth0 gateway."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.0.1"
+ETH0_MASK="255.255.255.0"
+ETH0_GATEWAY="10.0.0.254"
+ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH1_GATEWAY="192.168.1.254"
+GATEWAY_IFACE="1"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 2
+        eth0 = next(i for i in config.interfaces if i.name == "eth0")
+        eth1 = next(i for i in config.interfaces if i.name == "eth1")
+        assert eth0.gateway is None
+        assert str(eth1.gateway) == "192.168.1.254"
+
+    def test_gateway_iface_0_preserves_eth0_suppresses_eth1(self, tmp_path: Path) -> None:
+        """GATEWAY_IFACE=0 keeps eth0 gateway and nulls eth1 gateway."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.0.1"
+ETH0_MASK="255.255.255.0"
+ETH0_GATEWAY="10.0.0.254"
+ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH1_GATEWAY="192.168.1.254"
+GATEWAY_IFACE="0"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 2
+        eth0 = next(i for i in config.interfaces if i.name == "eth0")
+        eth1 = next(i for i in config.interfaces if i.name == "eth1")
+        assert str(eth0.gateway) == "10.0.0.254"
+        assert eth1.gateway is None
+
+    def test_gateway_iface_invalid_logs_warning_leaves_gateways_unchanged(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """GATEWAY_IFACE=foo logs a warning and leaves all gateways unchanged."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.0.1"
+ETH0_MASK="255.255.255.0"
+ETH0_GATEWAY="10.0.0.254"
+ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH1_GATEWAY="192.168.1.254"
+GATEWAY_IFACE="foo"
+"""
+        context_file.write_text(content)
+
+        with caplog.at_level(logging.WARNING, logger="vyos_onecontext.parser"):
+            config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 2
+        eth0 = next(i for i in config.interfaces if i.name == "eth0")
+        eth1 = next(i for i in config.interfaces if i.name == "eth1")
+        assert str(eth0.gateway) == "10.0.0.254"
+        assert str(eth1.gateway) == "192.168.1.254"
+        assert any("GATEWAY_IFACE" in record.message for record in caplog.records)
+
+    def test_gateway_iface_absent_leaves_gateways_unchanged(self, tmp_path: Path) -> None:
+        """Without GATEWAY_IFACE, all interface gateways are preserved as-is."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.0.1"
+ETH0_MASK="255.255.255.0"
+ETH0_GATEWAY="10.0.0.254"
+ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH1_GATEWAY="192.168.1.254"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 2
+        eth0 = next(i for i in config.interfaces if i.name == "eth0")
+        eth1 = next(i for i in config.interfaces if i.name == "eth1")
+        assert str(eth0.gateway) == "10.0.0.254"
+        assert str(eth1.gateway) == "192.168.1.254"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1381,3 +1381,93 @@ ETH0_MASK="255.255.255.0"
         iface = config.interfaces[0]
         assert iface.gateway is None
         assert iface.dns is None
+
+
+class TestIgnoreGateway:
+    """Tests for ETHx_IGNORE_GATEWAY suppression."""
+
+    def test_ignore_gateway_yes_suppresses_gateway(self, tmp_path: Path) -> None:
+        """ETH1_IGNORE_GATEWAY=yes suppresses gateway even when ETH1_GATEWAY is set."""
+        context_file = tmp_path / "one_env"
+        content = """ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH1_GATEWAY="192.168.1.254"
+ETH1_IGNORE_GATEWAY="yes"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 1
+        iface = config.interfaces[0]
+        assert iface.name == "eth1"
+        assert iface.gateway is None
+
+    def test_ignore_gateway_uppercase_suppresses_gateway(self, tmp_path: Path) -> None:
+        """ETH1_IGNORE_GATEWAY=YES (uppercase) also suppresses gateway."""
+        context_file = tmp_path / "one_env"
+        content = """ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH1_GATEWAY="192.168.1.254"
+ETH1_IGNORE_GATEWAY="YES"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 1
+        iface = config.interfaces[0]
+        assert iface.gateway is None
+
+    def test_ignore_gateway_no_does_not_suppress(self, tmp_path: Path) -> None:
+        """ETH1_IGNORE_GATEWAY=no does NOT suppress the gateway."""
+        context_file = tmp_path / "one_env"
+        content = """ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH1_GATEWAY="192.168.1.254"
+ETH1_IGNORE_GATEWAY="no"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 1
+        iface = config.interfaces[0]
+        assert str(iface.gateway) == "192.168.1.254"
+
+    def test_without_ignore_gateway_gateway_parsed_normally(self, tmp_path: Path) -> None:
+        """Without ETH1_IGNORE_GATEWAY, gateway is still parsed normally."""
+        context_file = tmp_path / "one_env"
+        content = """ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH1_GATEWAY="192.168.1.254"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 1
+        iface = config.interfaces[0]
+        assert str(iface.gateway) == "192.168.1.254"
+
+    def test_ignore_gateway_only_affects_specified_interface(self, tmp_path: Path) -> None:
+        """ETH1_IGNORE_GATEWAY=yes only suppresses eth1; eth0 still gets its gateway."""
+        context_file = tmp_path / "one_env"
+        content = """ETH0_IP="10.0.0.1"
+ETH0_MASK="255.255.255.0"
+ETH0_GATEWAY="10.0.0.254"
+
+ETH1_IP="192.168.1.1"
+ETH1_MASK="255.255.255.0"
+ETH1_GATEWAY="192.168.1.254"
+ETH1_IGNORE_GATEWAY="yes"
+"""
+        context_file.write_text(content)
+
+        config = parse_context(str(context_file))
+
+        assert len(config.interfaces) == 2
+        eth0 = next(i for i in config.interfaces if i.name == "eth0")
+        eth1 = next(i for i in config.interfaces if i.name == "eth1")
+        assert str(eth0.gateway) == "10.0.0.254"
+        assert eth1.gateway is None


### PR DESCRIPTION
## Summary

- Adds `ETHx_IGNORE_GATEWAY` context variable support to the interface parser
- When set to `\"yes\"` (case-insensitive), the gateway for that interface is treated as `None` even if `ETHx_GATEWAY` is also set
- Enables operators to suppress unwanted default routes on specific interfaces without removing the gateway from the context template
- Adds `GATEWAY_IFACE` context variable support (official OpenNebula variable)
- When set to an integer index N, only `eth{N}` retains its gateway; all other interface gateways are cleared
- Enables operators to declare which interface provides the default route using the standard OpenNebula mechanism

## Changes

- `src/vyos_onecontext/parser.py`: Check `ETHx_IGNORE_GATEWAY` after reading `ETHx_GATEWAY`; set `gateway = None` when the variable is `\"yes\"` (case-insensitive, whitespace-trimmed)
- `src/vyos_onecontext/parser.py`: Post-processing step `_apply_gateway_iface` reads `GATEWAY_IFACE`, parses it as an integer index, and nulls gateways on all interfaces that do not match `eth{N}`; invalid values log a warning
- `tests/test_parser.py`: New `TestIgnoreGateway` class with 5 tests covering: lowercase yes, uppercase YES, \"no\" does not suppress, absent variable parses normally, and per-interface isolation
- `tests/test_parser.py`: New `TestGatewayIface` class with 4 tests covering: index 1 preserves eth1, index 0 preserves eth0, invalid value logs warning and leaves gateways unchanged, absent variable leaves gateways unchanged

## Test plan

- [x] `ETH1_IGNORE_GATEWAY=yes` suppresses gateway
- [x] `ETH1_IGNORE_GATEWAY=YES` (uppercase) suppresses gateway
- [x] `ETH1_IGNORE_GATEWAY=no` does NOT suppress gateway
- [x] Absent `ETH1_IGNORE_GATEWAY` leaves gateway unaffected
- [x] Only the targeted interface is affected; other interfaces keep their gateways
- [x] `GATEWAY_IFACE=1` preserves eth1 gateway, clears eth0 gateway
- [x] `GATEWAY_IFACE=0` preserves eth0 gateway, clears eth1 gateway
- [x] `GATEWAY_IFACE=foo` logs a warning, both gateways unchanged
- [x] Absent `GATEWAY_IFACE` leaves all gateways unchanged
- [x] `just check` passes (842 passed, 20 skipped)

Closes #216
Closes #165

---
*AI-generated via Claude Code w/ Claude Sonnet 4.6 (1M context)*